### PR TITLE
Fix: Add sepa e2e id to firefly transaction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 vendor
+data
+!data/configurations/example.json
+.idea

--- a/app/TransactionsToFireflySender.php
+++ b/app/TransactionsToFireflySender.php
@@ -72,6 +72,7 @@ class TransactionsToFireflySender
                     'destination_name' => $destination['name'] ?? null,
                     'destination_id' => $destination['id'] ?? null,
                     'destination_iban' => $destination['iban'] ?? null,
+                    'sepa_ct_id' => $transaction->getEndToEndID() ?? null,
                 )
             )
         );


### PR DESCRIPTION
This fixes an edge-case where multiple transactions, with the same description, source, destination and amount are made on the same day. This might be the case with daily payments via PayPal (mobile phone contracts like FUNK for example).

Adding the sepa end to end ID adds a truly unique identifier to each transaction so similar looking ones are not treated as duplicates.

And some additions to the `.gitignore` that I thought were quite useful.