### PR TITLE
Skip steps which do not require user interaction

### DIFF
--- a/app/Choose2FADevice.php
+++ b/app/Choose2FADevice.php
@@ -19,6 +19,7 @@ function Choose2FADevice()
     $session->set('bank_2fa', $request->request->get('bank_2fa'));
     $session->set('firefly_url', $request->request->get('firefly_url'));
     $session->set('firefly_access_token', $request->request->get('firefly_access_token'));
+    $session->set('automate', $request->request->get('automate'));
     $fin_ts   = FinTsFactory::create_from_session($session);
     $tan_mode = FinTsFactory::get_tan_mode($fin_ts, $session);
 
@@ -34,7 +35,8 @@ function Choose2FADevice()
             'skip-form.twig',
             array(
                 'next_step' => Step::STEP2_LOGIN,
-                'message' => "Your chosen tan mode does not require you to choose a device."
+                'message' => "Your chosen tan mode does not require you to choose a device.",
+                'automate' => $session->get('automate')
             )
         );
     }

--- a/app/Choose2FADevice.php
+++ b/app/Choose2FADevice.php
@@ -1,0 +1,41 @@
+<?php
+namespace App\StepFunction;
+
+use App\FinTsFactory;
+use App\Step;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+
+function Choose2FADevice()
+{
+    global $request, $session, $twig;
+
+    $session->invalidate();
+    $session->set('bank_username', $request->request->get('bank_username'));
+    // Hm, this most likely stores the password on disk somewhere. Could we at least scramble it a bit?
+    $session->set('bank_password', $request->request->get('bank_password'));
+    $session->set('bank_url', $request->request->get('bank_url'));
+    $session->set('bank_code', $request->request->get('bank_code'));
+    $session->set('bank_2fa', $request->request->get('bank_2fa'));
+    $session->set('firefly_url', $request->request->get('firefly_url'));
+    $session->set('firefly_access_token', $request->request->get('firefly_access_token'));
+    $fin_ts   = FinTsFactory::create_from_session($session);
+    $tan_mode = FinTsFactory::get_tan_mode($fin_ts, $session);
+
+    if ($tan_mode->needsTanMedium()) {
+        echo $twig->render(
+            'choose-2fa-device.twig',
+            array(
+                'next_step' => Step::STEP2_LOGIN,
+                'devices' => $fin_ts->getTanMedia($tan_mode)
+            ));
+    } else {
+        echo $twig->render(
+            'skip-form.twig',
+            array(
+                'next_step' => Step::STEP2_LOGIN,
+                'message' => "Your chosen tan mode does not require you to choose a device."
+            )
+        );
+    }
+}

--- a/app/ChooseAccount.php
+++ b/app/ChooseAccount.php
@@ -1,0 +1,51 @@
+<?php
+namespace App\StepFunction;
+
+use App\FinTsFactory;
+use App\Step;
+use App\TanHandler;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use GrumpyDictator\FFIIIApiSupport\Request\GetAccountsRequest;
+
+function ChooseAccount()
+{
+    global $request, $session, $twig, $fin_ts;
+
+    $fin_ts = FinTsFactory::create_from_session($session);
+    $current_step  = new Step($request->request->get("step", Step::STEP0_SETUP));
+    $list_accounts_handler = new TanHandler(
+        function () {
+            global $fin_ts;
+            $get_sepa_accounts = \Fhp\Action\GetSEPAAccounts::create();
+            $fin_ts->execute($get_sepa_accounts);
+            return $get_sepa_accounts;
+        },
+        'list-accounts',
+        $session,
+        $twig,
+        $fin_ts,
+        $current_step,
+        $request
+    );
+    if ($list_accounts_handler->needs_tan()) {
+        $list_accounts_handler->pose_and_render_tan_challenge();
+    } else {
+        $bank_accounts            = $list_accounts_handler->get_finished_action()->getAccounts();
+        $firefly_accounts_request = new GetAccountsRequest($session->get('firefly_url'), $session->get('firefly_access_token'));
+        $firefly_accounts_request->setType(GetAccountsRequest::ASSET);
+        $firefly_accounts = $firefly_accounts_request->get();
+        echo $twig->render(
+            'choose-account.twig',
+            array(
+                'next_step' => Step::STEP4_GET_IMPORT_DATA,
+                'bank_accounts' => $bank_accounts,
+                'firefly_accounts' => $firefly_accounts,
+                'default_from_date' => new \DateTime('now - 1 month'),
+                'default_to_date' => new \DateTime('now')
+            )
+        );
+        $session->set('accounts', serialize($bank_accounts));
+    }
+    $session->set('persistedFints', $fin_ts->persist());
+}

--- a/app/CollectData.php
+++ b/app/CollectData.php
@@ -45,6 +45,7 @@ function CollectData()
         $session->set('bank_2fa',             $configuration->bank_2fa);
         $session->set('firefly_url',          $configuration->firefly_url);
         $session->set('firefly_access_token', $configuration->firefly_access_token);
+        $session->set('automate',             $configuration->automate);
 
         $fin_ts   = FinTsFactory::create_from_session($session);
         $tan_mode = FinTsFactory::get_tan_mode($fin_ts, $session);
@@ -61,7 +62,8 @@ function CollectData()
                 'skip-form.twig',
                 array(
                     'next_step' => Step::STEP2_LOGIN,
-                    'message' => "Your chosen tan mode does not require you to choose a device."
+                    'message' => "Your chosen tan mode does not require you to choose a device.",
+                    'automate' => $session->get('automate')
                 )
             );
         }

--- a/app/CollectData.php
+++ b/app/CollectData.php
@@ -1,0 +1,69 @@
+<?php
+namespace App\StepFunction;
+
+use App\FinTsFactory;
+use App\ConfigurationFactory;
+use App\Step;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+
+function CollectData()
+{
+    global $request, $session, $twig;
+
+    if($request->request->get('data_collect_mode') == "createNewDataset"){
+        echo $twig->render(
+            'collecting-data.twig',
+            array(
+                'next_step' => Step::STEP1p5_CHOOSE_2FA_DEVICE
+            ));
+    } else {
+        $session->invalidate();
+
+        $filename = $request->request->get('data_collect_mode');
+        $configuration = ConfigurationFactory::load_from_file($filename);
+
+        if ($configuration->bank_username == "" || $configuration->bank_password == "") {
+            $configuration->bank_username = $request->request->get('bank_username');
+            $configuration->bank_password = $request->request->get('bank_password');
+            if ($configuration->bank_username == "" || $configuration->bank_password == "") {
+                echo $twig->render(
+                    'collecting-data.twig',
+                    array(
+                        'next_step' => Step::STEP1_COLLECTING_DATA,
+                        'configuration' => $configuration,
+                        'data_collect_mode' => $filename
+                    ));
+                return;
+            }
+        }
+
+        $session->set('bank_username',        $configuration->bank_username);
+        $session->set('bank_password',        $configuration->bank_password);
+        $session->set('bank_url',             $configuration->bank_url);
+        $session->set('bank_code',            $configuration->bank_code);
+        $session->set('bank_2fa',             $configuration->bank_2fa);
+        $session->set('firefly_url',          $configuration->firefly_url);
+        $session->set('firefly_access_token', $configuration->firefly_access_token);
+
+        $fin_ts   = FinTsFactory::create_from_session($session);
+        $tan_mode = FinTsFactory::get_tan_mode($fin_ts, $session);
+
+        if ($tan_mode->needsTanMedium()) {
+            echo $twig->render(
+                'choose-2fa-device.twig',
+                array(
+                    'next_step' => Step::STEP2_LOGIN,
+                    'devices' => $fin_ts->getTanMedia($tan_mode)
+                ));
+        } else {
+            echo $twig->render(
+                'skip-form.twig',
+                array(
+                    'next_step' => Step::STEP2_LOGIN,
+                    'message' => "Your chosen tan mode does not require you to choose a device."
+                )
+            );
+        }
+    }
+}

--- a/app/ConfigurationFactory.php
+++ b/app/ConfigurationFactory.php
@@ -11,6 +11,7 @@ class Configuration {
     public $bank_2fa;
     public $firefly_url;
     public $firefly_access_token;
+    public $automate;
 }
 
 class ConfigurationFactory
@@ -30,6 +31,7 @@ static function load_from_file($fileName)
         $configuration->bank_2fa             = $contentArray["bank_2fa"];
         $configuration->firefly_url          = $contentArray["firefly_url"];
         $configuration->firefly_access_token = $contentArray["firefly_access_token"];
+        $configuration->automate             = filter_var($contentArray["automate"], FILTER_VALIDATE_BOOLEAN);;
 
         return $configuration;
     }

--- a/app/GetImportData.php
+++ b/app/GetImportData.php
@@ -47,7 +47,8 @@ function GetImportData()
             'show-transactions.twig',
             array(
                 'transactions' => $transactions,
-                'next_step' => Step::STEP5_RUN_IMPORT
+                'next_step' => Step::STEP5_RUN_IMPORT,
+                'automate' => $session->get('firefly_url')
             )
         );
         $session->set('transactions_to_import', serialize($transactions));

--- a/app/GetImportData.php
+++ b/app/GetImportData.php
@@ -1,0 +1,58 @@
+<?php
+namespace App\StepFunction;
+
+use App\FinTsFactory;
+use App\Step;
+use App\TanHandler;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+
+function GetImportData()
+{
+    global $request, $session, $twig, $fin_ts, $accounts;
+
+    $fin_ts = FinTsFactory::create_from_session($session);
+
+    $accounts = unserialize($session->get('accounts'));
+    $current_step  = new Step($request->request->get("step", Step::STEP0_SETUP));
+    $soa_handler = new TanHandler(
+        function () {
+            global $fin_ts, $request, $accounts, $session;
+            assert($request->request->has('bank_account'));
+            assert($request->request->has('firefly_account'));
+            assert($request->request->has('date_from'));
+            assert($request->request->has('date_to'));
+            $bank_account = $accounts[intval($request->request->get('bank_account'))];
+            $from         = new \DateTime($request->request->get('date_from'));
+            $to           = new \DateTime($request->request->get('date_to'));
+            $session->set('firefly_account', $request->request->get('firefly_account'));
+            $get_statement = \Fhp\Action\GetStatementOfAccount::create($bank_account, $from, $to);
+            $fin_ts->execute($get_statement);
+            return $get_statement;
+        },
+        'soa',
+        $session,
+        $twig,
+        $fin_ts,
+        $current_step,
+        $request
+    );
+    if ($soa_handler->needs_tan()) {
+        $soa_handler->pose_and_render_tan_challenge();
+    } else {
+        /** @var \Fhp\Model\StatementOfAccount\StatementOfAccount $soa */
+        $soa          = $soa_handler->get_finished_action()->getStatement();
+        $transactions = \App\StatementOfAccountHelper::get_all_transactions($soa);
+        echo $twig->render(
+            'show-transactions.twig',
+            array(
+                'transactions' => $transactions,
+                'next_step' => Step::STEP5_RUN_IMPORT
+            )
+        );
+        $session->set('transactions_to_import', serialize($transactions));
+        $session->set('num_transactions_processed', 0);
+        $session->set('import_messages', serialize(array()));
+    }
+    $session->set('persistedFints', $fin_ts->persist());
+}

--- a/app/Login.php
+++ b/app/Login.php
@@ -1,0 +1,45 @@
+<?php
+namespace App\StepFunction;
+
+use App\FinTsFactory;
+use App\Step;
+use App\TanHandler;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+
+function Login()
+{
+    global $request, $session, $twig, $fin_ts;
+
+    if ($request->request->has('bank_2fa_device')) {
+        $session->set('bank_2fa_device', $request->request->get('bank_2fa_device'));
+    }
+    $fin_ts = FinTsFactory::create_from_session($session);
+
+    $current_step  = new Step($request->request->get("step", Step::STEP0_SETUP));
+    $login_handler = new TanHandler(
+        function () {
+            global $fin_ts;
+            return $fin_ts->login();
+        },
+        'login-action',
+        $session,
+        $twig,
+        $fin_ts,
+        $current_step,
+        $request
+    );
+
+    if ($login_handler->needs_tan()) {
+        $login_handler->pose_and_render_tan_challenge();
+    } else {
+        echo $twig->render(
+            'skip-form.twig',
+            array(
+                'next_step' => Step::STEP3_CHOOSE_ACCOUNT,
+                'message' => "The connection to your bank was tested sucessfully."
+            )
+        );
+    }
+    $session->set('persistedFints', $fin_ts->persist());
+}

--- a/app/Login.php
+++ b/app/Login.php
@@ -37,7 +37,8 @@ function Login()
             'skip-form.twig',
             array(
                 'next_step' => Step::STEP3_CHOOSE_ACCOUNT,
-                'message' => "The connection to your bank was tested sucessfully."
+                'message' => "The connection to your bank was tested sucessfully.",
+                'automate' => $session->get('automate')
             )
         );
     }

--- a/app/RunImport.php
+++ b/app/RunImport.php
@@ -1,0 +1,55 @@
+<?php
+namespace App\StepFunction;
+
+use App\TransactionsToFireflySender;
+use App\Step;
+use Symfony\Component\HttpFoundation\Session\Session;
+
+function RunImport()
+{
+    global $session, $twig;
+
+    $num_transactions_to_import_at_once = 5;
+    assert($session->has('transactions_to_import'));
+    assert($session->has('num_transactions_processed'));
+    assert($session->has('import_messages'));
+    assert($session->has('firefly_account'));
+    $transactions                = unserialize($session->get('transactions_to_import'));
+    $num_transactions_processed  = $session->get('num_transactions_processed');
+    $import_messages             = unserialize($session->get('import_messages'));
+    $transactions_to_process_now = array_slice($transactions, $num_transactions_processed, $num_transactions_to_import_at_once);
+    if (empty($transactions_to_process_now)) {
+        echo $twig->render(
+            'done.twig',
+            array(
+                'import_messages' => $import_messages,
+                'total_num_transactions' => count($transactions)
+            )
+        );
+        $session->invalidate();
+    } else {
+        $num_transactions_processed += count($transactions_to_process_now);
+        $sender                     = new TransactionsToFireflySender(
+            $transactions_to_process_now,
+            $session->get('firefly_url'),
+            $session->get('firefly_access_token'),
+            $session->get('firefly_account')
+        );
+        $result                     = $sender->send_transactions();
+        if (is_array($result)) {
+            $import_messages = array_merge($import_messages, $result);
+        }
+
+        $session->set('num_transactions_processed', $num_transactions_processed);
+        $session->set('import_messages', serialize($import_messages));
+
+        echo $twig->render(
+            'import-progress.twig',
+            array(
+                'num_transactions_processed' => $num_transactions_processed,
+                'total_num_transactions' => count($transactions),
+                'next_step' => Step::STEP5_RUN_IMPORT
+            )
+        );
+    }
+}

--- a/app/Setup.php
+++ b/app/Setup.php
@@ -1,0 +1,24 @@
+<?php
+namespace App\StepFunction;
+
+use App\Step;
+
+function Setup()
+{
+    global $twig;
+
+    $configuration_files = array();
+    $dirs = array('/app/configurations', 'data/configurations');
+    foreach($dirs as $dir){
+        if (file_exists($dir))
+            $configuration_files = array_merge($configuration_files,
+                preg_filter('/^/', $dir.DIRECTORY_SEPARATOR, array_diff(scandir($dir), array('.', '..') )));
+    }
+
+    echo $twig->render(
+        'setup.twig',
+        array(
+            'files' => $configuration_files,
+            'next_step' => Step::STEP1_COLLECTING_DATA
+        ));
+}

--- a/app/configurations/example.json
+++ b/app/configurations/example.json
@@ -5,5 +5,6 @@
   "bank_url": "https://hbci11.fiducia.de/cgi-bin/hbciservlet",
   "bank_2fa": "944",
   "firefly_url": "",
-  "firefly_access_token": ""
+  "firefly_access_token": "",
+  "automate": "false"
 }

--- a/app/index.php
+++ b/app/index.php
@@ -6,6 +6,15 @@ error_reporting(E_ALL);
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
+include 'Setup.php';
+include 'CollectData.php';
+include 'Choose2FADevice.php';
+include 'Login.php';
+include 'ChooseAccount.php';
+include 'GetImportData.php';
+include 'RunImport.php';
+
+use App\StepFunction;
 use App\FinTsFactory;
 use App\ConfigurationFactory;
 use App\TanHandler;
@@ -26,269 +35,34 @@ $session = new Session();
 $session->start();
 
 
+
 switch ((string)$current_step) {
     case Step::STEP0_SETUP:
-        $configuration_files = array();
-        $dirs = array('/app/configurations', 'data/configurations');
-        foreach($dirs as $dir){
-            if (file_exists($dir))
-                $configuration_files = array_merge($configuration_files,
-                    preg_filter('/^/', $dir.DIRECTORY_SEPARATOR, array_diff(scandir($dir), array('.', '..') )));
-        }
-
-        echo $twig->render(
-            'setup.twig',
-            array(
-                'files' => $configuration_files,
-                'next_step' => Step::STEP1_COLLECTING_DATA
-            ));
+        StepFunction\Setup();
         break;
+
     case Step::STEP1_COLLECTING_DATA:
-        if($request->request->get('data_collect_mode') == "createNewDataset"){
-            echo $twig->render(
-                'collecting-data.twig',
-                array(
-                    'next_step' => Step::STEP1p5_CHOOSE_2FA_DEVICE
-                ));
-        } else {
-            $session->invalidate();
-
-            $filename = $request->request->get('data_collect_mode');
-            $configuration = ConfigurationFactory::load_from_file($filename);
-
-            if ($configuration->bank_username == "" || $configuration->bank_password == "") {
-                $configuration->bank_username = $request->request->get('bank_username');
-                $configuration->bank_password = $request->request->get('bank_password');
-                if ($configuration->bank_username == "" || $configuration->bank_password == "") {
-                    echo $twig->render(
-                        'collecting-data.twig',
-                        array(
-                            'next_step' => Step::STEP1_COLLECTING_DATA,
-                            'configuration' => $configuration,
-                            'data_collect_mode' => $filename
-                        ));
-                    break;
-                }
-            }
-
-            $session->set('bank_username',        $configuration->bank_username);
-            $session->set('bank_password',        $configuration->bank_password);
-            $session->set('bank_url',             $configuration->bank_url);
-            $session->set('bank_code',            $configuration->bank_code);
-            $session->set('bank_2fa',             $configuration->bank_2fa);
-            $session->set('firefly_url',          $configuration->firefly_url);
-            $session->set('firefly_access_token', $configuration->firefly_access_token);
-
-            $fin_ts   = FinTsFactory::create_from_session($session);
-            $tan_mode = FinTsFactory::get_tan_mode($fin_ts, $session);
-
-            if ($tan_mode->needsTanMedium()) {
-                echo $twig->render(
-                    'choose-2fa-device.twig',
-                    array(
-                        'next_step' => Step::STEP2_LOGIN,
-                        'devices' => $fin_ts->getTanMedia($tan_mode)
-                    ));
-            } else {
-                echo $twig->render(
-                    'skip-form.twig',
-                    array(
-                        'next_step' => Step::STEP2_LOGIN,
-                        'message' => "Your chosen tan mode does not require you to choose a device."
-                    )
-                );
-            }
-        }
-
-
-
+        StepFunction\CollectData();
         break;
+
     case Step::STEP1p5_CHOOSE_2FA_DEVICE:
-        $session->invalidate();
-        $session->set('bank_username', $request->request->get('bank_username'));
-        // Hm, this most likely stores the password on disk somewhere. Could we at least scramble it a bit?
-        $session->set('bank_password', $request->request->get('bank_password'));
-        $session->set('bank_url', $request->request->get('bank_url'));
-        $session->set('bank_code', $request->request->get('bank_code'));
-        $session->set('bank_2fa', $request->request->get('bank_2fa'));
-        $session->set('firefly_url', $request->request->get('firefly_url'));
-        $session->set('firefly_access_token', $request->request->get('firefly_access_token'));
-        $fin_ts   = FinTsFactory::create_from_session($session);
-        $tan_mode = FinTsFactory::get_tan_mode($fin_ts, $session);
-
-        if ($tan_mode->needsTanMedium()) {
-            echo $twig->render(
-                'choose-2fa-device.twig',
-                array(
-                    'next_step' => Step::STEP2_LOGIN,
-                    'devices' => $fin_ts->getTanMedia($tan_mode)
-                ));
-        } else {
-            echo $twig->render(
-                'skip-form.twig',
-                array(
-                    'next_step' => Step::STEP2_LOGIN,
-                    'message' => "Your chosen tan mode does not require you to choose a device."
-                )
-            );
-        }
+        StepFunction\Choose2FADevice();
         break;
+
     case Step::STEP2_LOGIN:
-        if ($request->request->has('bank_2fa_device')) {
-            $session->set('bank_2fa_device', $request->request->get('bank_2fa_device'));
-        }
-
-        $fin_ts        = FinTsFactory::create_from_session($session);
-        $login_handler = new TanHandler(
-            function () {
-                global $fin_ts;
-                return $fin_ts->login();
-            },
-            'login-action',
-            $session,
-            $twig,
-            $fin_ts,
-            $current_step,
-            $request
-        );
-        if ($login_handler->needs_tan()) {
-            $login_handler->pose_and_render_tan_challenge();
-        } else {
-            echo $twig->render(
-                'skip-form.twig',
-                array(
-                    'next_step' => Step::STEP3_CHOOSE_ACCOUNT,
-                    'message' => "The connection to your bank was tested sucessfully."
-                )
-            );
-        }
-        $session->set('persistedFints', $fin_ts->persist());
+        StepFunction\Login();
         break;
+
     case Step::STEP3_CHOOSE_ACCOUNT:
-        $fin_ts                = FinTsFactory::create_from_session($session);
-        $list_accounts_handler = new TanHandler(
-            function () {
-                global $fin_ts;
-                $get_sepa_accounts = \Fhp\Action\GetSEPAAccounts::create();
-                $fin_ts->execute($get_sepa_accounts);
-                return $get_sepa_accounts;
-            },
-            'list-accounts',
-            $session,
-            $twig,
-            $fin_ts,
-            $current_step,
-            $request
-        );
-        if ($list_accounts_handler->needs_tan()) {
-            $list_accounts_handler->pose_and_render_tan_challenge();
-        } else {
-            $bank_accounts            = $list_accounts_handler->get_finished_action()->getAccounts();
-            $firefly_accounts_request = new GetAccountsRequest($session->get('firefly_url'), $session->get('firefly_access_token'));
-            $firefly_accounts_request->setType(GetAccountsRequest::ASSET);
-            $firefly_accounts = $firefly_accounts_request->get();
-            echo $twig->render(
-                'choose-account.twig',
-                array(
-                    'next_step' => Step::STEP4_GET_IMPORT_DATA,
-                    'bank_accounts' => $bank_accounts,
-                    'firefly_accounts' => $firefly_accounts,
-                    'default_from_date' => new \DateTime('now - 1 month'),
-                    'default_to_date' => new \DateTime('now')
-                )
-            );
-            $session->set('accounts', serialize($bank_accounts));
-        }
-        $session->set('persistedFints', $fin_ts->persist());
+        StepFunction\ChooseAccount();
         break;
+
     case Step::STEP4_GET_IMPORT_DATA:
-        $fin_ts   = FinTsFactory::create_from_session($session);
-        $accounts = unserialize($session->get('accounts'));
-        $soa_handler = new TanHandler(
-            function () {
-                global $fin_ts, $request, $accounts, $session;
-                assert($request->request->has('bank_account'));
-                assert($request->request->has('firefly_account'));
-                assert($request->request->has('date_from'));
-                assert($request->request->has('date_to'));
-                $bank_account = $accounts[intval($request->request->get('bank_account'))];
-                $from         = new \DateTime($request->request->get('date_from'));
-                $to           = new \DateTime($request->request->get('date_to'));
-                $session->set('firefly_account', $request->request->get('firefly_account'));
-                $get_statement = \Fhp\Action\GetStatementOfAccount::create($bank_account, $from, $to);
-                $fin_ts->execute($get_statement);
-                return $get_statement;
-            },
-            'soa',
-            $session,
-            $twig,
-            $fin_ts,
-            $current_step,
-            $request
-        );
-        if ($soa_handler->needs_tan()) {
-            $soa_handler->pose_and_render_tan_challenge();
-        } else {
-            /** @var \Fhp\Model\StatementOfAccount\StatementOfAccount $soa */
-            $soa          = $soa_handler->get_finished_action()->getStatement();
-            $transactions = \App\StatementOfAccountHelper::get_all_transactions($soa);
-            echo $twig->render(
-                'show-transactions.twig',
-                array(
-                    'transactions' => $transactions,
-                    'next_step' => Step::STEP5_RUN_IMPORT
-                )
-            );
-            $session->set('transactions_to_import', serialize($transactions));
-            $session->set('num_transactions_processed', 0);
-            $session->set('import_messages', serialize(array()));
-        }
-        $session->set('persistedFints', $fin_ts->persist());
+        StepFunction\GetImportData();
         break;
+
     case Step::STEP5_RUN_IMPORT:
-        $num_transactions_to_import_at_once = 5;
-        assert($session->has('transactions_to_import'));
-        assert($session->has('num_transactions_processed'));
-        assert($session->has('import_messages'));
-        assert($session->has('firefly_account'));
-        $transactions                = unserialize($session->get('transactions_to_import'));
-        $num_transactions_processed  = $session->get('num_transactions_processed');
-        $import_messages             = unserialize($session->get('import_messages'));
-        $transactions_to_process_now = array_slice($transactions, $num_transactions_processed, $num_transactions_to_import_at_once);
-        if (empty($transactions_to_process_now)) {
-            echo $twig->render(
-                'done.twig',
-                array(
-                    'import_messages' => $import_messages,
-                    'total_num_transactions' => count($transactions)
-                )
-            );
-            $session->invalidate();
-        } else {
-            $num_transactions_processed += count($transactions_to_process_now);
-            $sender                     = new TransactionsToFireflySender(
-                $transactions_to_process_now,
-                $session->get('firefly_url'),
-                $session->get('firefly_access_token'),
-                $session->get('firefly_account')
-            );
-            $result                     = $sender->send_transactions();
-            if (is_array($result)) {
-                $import_messages = array_merge($import_messages, $result);
-            }
-
-            $session->set('num_transactions_processed', $num_transactions_processed);
-            $session->set('import_messages', serialize($import_messages));
-
-            echo $twig->render(
-                'import-progress.twig',
-                array(
-                    'num_transactions_processed' => $num_transactions_processed,
-                    'total_num_transactions' => count($transactions),
-                    'next_step' => Step::STEP5_RUN_IMPORT
-                )
-            );
-        }
+        StepFunction\RunImport();
         break;
 
     default:

--- a/app/public/html/choose-account.twig
+++ b/app/public/html/choose-account.twig
@@ -5,7 +5,7 @@
 {% block content %}
     <h1>Choose an account to import from and to</h1>
 
-    <form action="." method="post">
+    <form name="next-form" action="." method="post">
         <input type="hidden" name="step" value="{{ next_step }}">
         <div class="form-group">
             <label for="bank_account">Bank Account</label>

--- a/app/public/html/show-transactions.twig
+++ b/app/public/html/show-transactions.twig
@@ -7,7 +7,7 @@
     
     <p>The following transactions will be imported to Firefly III.</p>
 
-    <form action="." method="post">
+    <form name="next-form" action="." method="post">
         <input type="hidden" name="step" value="{{ next_step }}">
         <button type="submit" class="btn btn-primary">Import transactions to FireflyIII</button>
     </form>
@@ -31,4 +31,12 @@
         </div>
     {% endfor %}
     </ul>
+
+    {% if automate %}
+        <script>
+            window.onload = function() {
+                document.forms["next-form"].submit();
+            }
+        </script>
+    {% endif %}
 {% endblock %}

--- a/app/public/html/skip-form.twig
+++ b/app/public/html/skip-form.twig
@@ -7,8 +7,17 @@
     
     <p>{{ message }}</p>
 
-    <form action="." method="post">
+    <form name="next-form" action="." method="post">
         <input type="hidden" name="step" value="{{ next_step }}">
         <button type="submit" class="btn btn-primary">Proceed</button>
     </form>
+
+    {% if automate %}
+        <script>
+            window.onload = function() {
+                document.forms["next-form"].submit();
+            }
+        </script>
+    {% endif %}
+
 {% endblock %}

--- a/data/configurations/example.json
+++ b/data/configurations/example.json
@@ -5,5 +5,6 @@
   "bank_url": "https://hbci11.fiducia.de/cgi-bin/hbciservlet",
   "bank_2fa": "944",
   "firefly_url": "",
-  "firefly_access_token": ""
+  "firefly_access_token": "",
+  "automate": "false"
 }


### PR DESCRIPTION
The first commit moves the code for a step into its own file in the namespace `StepFunctions`. For me it was easier to work in the different files and not have to scroll around that much.

The second commit skips steps which do not require user interaction (Implements #38). Can be turned on/off through the configuration file. 
Basically it is just a 
```
<script>
window.onload = function() {
    document.forms["next-form"].submit();
}
</script>
```
in the `.twig` file.

This is my first "real" commit for a PHP Codebase. Feedback, comments are appreciated, since i currently do not know the good way of writing PHP code and all of its available functions.


Further development (later):
- Make the Bank and Firefly account selection automated through values in the configuration
- Maybe notify if "skip steps" is turned on and a TAN is needed (Need to think about the design more)
- Call the Importer automatically every day/week/hour somehow. (Could be external)