### PR TITLE
Choose configfile through URL parameter

### DIFF
--- a/app/Setup.php
+++ b/app/Setup.php
@@ -7,6 +7,23 @@ function Setup()
 {
     global $twig;
 
+    $requested_config_file = '';
+
+    if (isset($_GET['config'])) {
+        $filename = basename($_GET['config']);
+        $requested_config_file = 'data/configurations/' . $filename;
+        if (!file_exists($requested_config_file)) {
+            echo $twig->render(
+                'error.twig',
+                array(
+                    'error_header' => 'Could not find the configuration',
+                    'error_message' => 'The configuration \'' . $filename . '\' could\'t be found in the directory \'data/configurations/\''
+                )
+            );
+            return;
+        }
+    }
+
     $configuration_files = array();
     $dirs = array('/app/configurations', 'data/configurations');
     foreach($dirs as $dir){
@@ -19,6 +36,7 @@ function Setup()
         'setup.twig',
         array(
             'files' => $configuration_files,
+            'requested_config_file' => $requested_config_file,
             'next_step' => Step::STEP1_COLLECTING_DATA
         ));
 }

--- a/app/public/html/error.twig
+++ b/app/public/html/error.twig
@@ -1,0 +1,9 @@
+{% extends 'base.twig' %}
+
+{% block title %}Error{% endblock %}
+
+{% block content %}
+    <h1>{{ error_header }}</h1>
+
+    <p>{{ error_message|nl2br }}</p>
+{% endblock %}

--- a/app/public/html/setup.twig
+++ b/app/public/html/setup.twig
@@ -3,19 +3,41 @@
 {% block title %}Enter account data{% endblock %}
 
 {% block content %}
-    <h1>Choose data source</h1>
-    <form action="." method="post">
+
+    {% if requested_config_file is empty %}
+        <h1>Choose data source</h1>
+    {% else %}
+        <h1>Continue to next step</h1>
+
+        <p>Continuing to next step in 2 seconds.</p>
+        
+        <script>
+            window.onload = function() {
+                setTimeout(function() {
+                    document.forms["next-form"].submit();
+                }, 2000);
+            }
+        </script>
+    {% endif %}
+
+    <form name="next-form" action="." method="post">
         <input type="hidden" name="step" value="{{ next_step }}">
         <fieldset class="mt-3">
             <div class="form-group">
                 <label for="bank_sfa">Configuration</label>
                 <select class="form-control" id="data_collect_mode" name="data_collect_mode" required>
-                    {% for file in files %}
-                        <option value="{{ file }}">{{ file }}</option>
-                    {% endfor %}
-                    <option value="createNewDataset">Manually fill out the configuration form</option>
+                    {% if requested_config_file is empty %}
+                        {% for file in files %}
+                            <option value="{{ file }}">{{ file }}</option>
+                        {% endfor %}
+                        <option value="createNewDataset">Manually fill out the configuration form</option>
+                    {% else %}
+                        <option value="{{ requested_config_file }}">{{ requested_config_file }}</option>
+                    {% endif %}
                 </select>
-                <small class="form-text text-muted">Choose a method to configure the importer. You can either select a configuration file that you created previously, or you can use the configuration form.</small>
+                {% if requested_config_file is empty %}
+                    <small class="form-text text-muted">Choose a method to configure the importer. You can either select a configuration file that you created previously, or you can use the configuration form.</small>
+                {% endif %}
             </div>
         </fieldset>
         <button type="submit" class="btn btn-primary">Submit</button>


### PR DESCRIPTION
Directly request the configuration indicated in the URL parameter.
http://firefly-iii-fints-importer-url.com/?config=example.json

In order to prevent directory traversal the `basename()` of the URL parameter is used and added at the end of `data/configuration/` (In this example it would be `data/configuration/example.json`. Ideas to solve this better and enable a more flexible approach in a future Pull Request?


The newly added file `error.twig` in this commit is the same from #63 . Should not created conflicts