### PR TITLE
Add support for description manipulation via regex fixes #29

### DIFF
--- a/app/Choose2FADevice.php
+++ b/app/Choose2FADevice.php
@@ -20,6 +20,8 @@ function Choose2FADevice()
     $session->set('firefly_url', $request->request->get('firefly_url'));
     $session->set('firefly_access_token', $request->request->get('firefly_access_token'));
     $session->set('skip_transaction_review', $request->request->get('skip_transaction_review'));
+    $session->set('description_regex_match', $request->request->get('description_regex_match'));
+    $session->set('description_regex_replace', $request->request->get('description_regex_replace'));
     $fin_ts   = FinTsFactory::create_from_session($session);
     $tan_mode = FinTsFactory::get_tan_mode($fin_ts, $session);
 

--- a/app/CollectData.php
+++ b/app/CollectData.php
@@ -50,6 +50,8 @@ function CollectData()
         $session->set('firefly_account_id',      $configuration->firefly_account_id);
         $session->set('choose_account_from' ,    $configuration->choose_account_from);
         $session->set('choose_account_to',       $configuration->choose_account_to);
+        $session->set('description_regex_match', $configuration->description_regex_match);
+        $session->set('description_regex_replace', $configuration->description_regex_replace);
 
         $fin_ts   = FinTsFactory::create_from_session($session);
         $tan_mode = FinTsFactory::get_tan_mode($fin_ts, $session);

--- a/app/ConfigurationFactory.php
+++ b/app/ConfigurationFactory.php
@@ -16,6 +16,8 @@ class Configuration {
     public $firefly_account_id;
     public $choose_account_from;
     public $choose_account_to;
+    public $description_regex_match;
+    public $description_regex_replace;
 }
 
 class ConfigurationFactory
@@ -45,6 +47,8 @@ class ConfigurationFactory
             $configuration->choose_account_from = NULL;
             $configuration->choose_account_to = NULL;
         }
+        $configuration->description_regex_match   = $contentArray["description_regex_match"];
+        $configuration->description_regex_replace = $contentArray["description_regex_replace"];
 
         return $configuration;
     }

--- a/app/RunImport.php
+++ b/app/RunImport.php
@@ -33,7 +33,9 @@ function RunImport()
             $transactions_to_process_now,
             $session->get('firefly_url'),
             $session->get('firefly_access_token'),
-            $session->get('firefly_account')
+            $session->get('firefly_account'),
+            $session->get('description_regex_match'),
+            $session->get('description_regex_replace')
         );
         $result                     = $sender->send_transactions();
         if (is_array($result)) {

--- a/app/TransactionsToFireflySender.php
+++ b/app/TransactionsToFireflySender.php
@@ -40,7 +40,8 @@ class TransactionsToFireflySender
 
     public static function transform_transaction_to_firefly_request_body(
         Transaction $transaction,
-        int $firefly_account_id
+        int $firefly_account_id,
+        string $regex_match, string $regex_replace
     )
     {
         $debitOrCredit = $transaction->getCreditDebit();
@@ -60,8 +61,8 @@ class TransactionsToFireflySender
             $description = $transaction->getBookingText();
         }
 
-        if($this->regex_match !== "" && $this->regex_replace !== "") {
-            $description = preg_replace($this->regex_match, $this->regex_replace, $description);
+        if($regex_match !== "" && $regex_replace !== "") {
+            $description = preg_replace($regex_match, $regex_replace, $description);
         }
 
         return array(
@@ -93,7 +94,7 @@ class TransactionsToFireflySender
             $request = new PostTransactionRequest($this->firefly_url, $this->firefly_access_token);
 
             $request->setBody(
-                self::transform_transaction_to_firefly_request_body($transaction, $this->firefly_account_id)
+                self::transform_transaction_to_firefly_request_body($transaction, $this->firefly_account_id, $this->regex_match, $this->regex_replace)
             );
 
             $response = $request->post();

--- a/app/TransactionsToFireflySender.php
+++ b/app/TransactionsToFireflySender.php
@@ -65,6 +65,10 @@ class TransactionsToFireflySender
             $description = preg_replace($regex_match, $regex_replace, $description);
         }
 
+        if($description == null) {
+            throw new \Exception("Error in regular expression!\nMatch expression {$regex_match}\nReplace expression {$regex_replace}");
+        }
+
         return array(
             'apply_rules' => true,
             'error_if_duplicate_hash' => true,

--- a/app/TransactionsToFireflySender.php
+++ b/app/TransactionsToFireflySender.php
@@ -17,12 +17,15 @@ class TransactionsToFireflySender
      * @param $firefly_access_token string
      * @param int $firefly_account_id
      */
-    public function __construct(array $transactions, string $firefly_url, string $firefly_access_token, int $firefly_account_id)
+    public function __construct(array $transactions, string $firefly_url, string $firefly_access_token, 
+                                int $firefly_account_id, string $regex_match, string $regex_replace)
     {
         $this->transactions         = $transactions;
         $this->firefly_url          = $firefly_url;
         $this->firefly_access_token = $firefly_access_token;
         $this->firefly_account_id   = $firefly_account_id;
+        $this->regex_match          = $regex_match;
+        $this->regex_replace        = $regex_replace;
     }
 
     public static function get_iban(Transaction $transaction)
@@ -55,6 +58,10 @@ class TransactionsToFireflySender
         $description = $transaction->getMainDescription();
         if ($description == "") {
             $description = $transaction->getBookingText();
+        }
+
+        if($this->regex_match !== "" && $this->regex_replace !== "") {
+            $description = preg_replace($this->regex_match, $this->regex_replace, $description);
         }
 
         return array(
@@ -108,4 +115,6 @@ class TransactionsToFireflySender
     private $firefly_url;
     private $firefly_access_token;
     private $firefly_account_id;
+    private $regex_match;
+    private $regex_replace;
 }

--- a/app/public/html/collecting-data.twig
+++ b/app/public/html/collecting-data.twig
@@ -89,7 +89,7 @@
                 <label for="description_regex_match">Match RegEx</label>
                 <input class="form-control" id="description_regex_match" name="description_regex_match">
                 <small class="form-text text-muted">
-                    If transaction description matches this RegEx, than it should be replaced by the next one.<br>
+                    If the transaction description matches this RegEx, then it should be replaced by the next one.<br>
                     Any valid <a href="https://www.php.net/manual/en/reference.pcre.pattern.syntax.php">PHP regex</a> will work.
                 </small>
             </div>

--- a/app/public/html/collecting-data.twig
+++ b/app/public/html/collecting-data.twig
@@ -82,6 +82,26 @@
             </div>
         </fieldset>
 	{% endif %}
+    {% if configuration.description_regex_match == "" %}
+        <fieldset class="mt-4">
+            <legend>Regular Expression for Description Manipulation</legend>
+            <div class="form-group">
+                <label for="description_regex_match">Match RegEx</label>
+                <input class="form-control" id="description_regex_match" name="description_regex_match">
+                <small class="form-text text-muted">
+                    If transaction description matches this RegEx, than it should be replaced by the next one.<br>
+                    Any valid <a href="https://www.php.net/manual/en/reference.pcre.pattern.syntax.php">PHP regex</a> will work.
+                </small>
+            </div>
+            <div class="form-group">
+                <label for="description_regex_replace">Replace RegEx</label>
+                <input class="form-control" id="description_regex_replace" name="description_regex_replace">
+                <small class="form-text text-muted">
+                    You probably want to use <a href="https://www.php.net/manual/en/regexp.reference.back-references.php">back references</a> here.
+                </small>
+            </div>
+        </fieldset>
+	{% endif %}
 	{% if data_collect_mode != "" %}
 	 <input type="hidden" id="data_collect_mode" name="data_collect_mode" value="{{ data_collect_mode }}"> 
 	{% endif %}

--- a/data/configurations/example.json
+++ b/data/configurations/example.json
@@ -7,6 +7,8 @@
   "firefly_url": "",
   "firefly_access_token": "",
   "skip_transaction_review": "false",
+  "description_regex_match": "/^(Übertrag \\/ Überweisung|Lastschrift \\/ Belastung)(.*)(END-TO-END-REF.*|Karte.*|KFN.*)(Ref\\..*)$/mi",
+  "description_regex_replace": "$2 [$1 | $3 | $4]",
   "choose_account_automation":
   {
     "bank_account_iban": "",

--- a/tests/TransactionsToFireflySenderTest.php
+++ b/tests/TransactionsToFireflySenderTest.php
@@ -51,7 +51,7 @@ final class TransactionsToFireflySenderTest extends TestCase
         );
         $actual   = TransactionsToFireflySender::transform_transaction_to_firefly_request_body(
             $transaction,
-            $this->firefly_account_id
+            $this->firefly_account_id, "", ""
         );
 
         $this->assertEquals($expected, $actual);
@@ -89,7 +89,7 @@ final class TransactionsToFireflySenderTest extends TestCase
         );
         $actual   = TransactionsToFireflySender::transform_transaction_to_firefly_request_body(
             $transaction,
-            $this->firefly_account_id
+            $this->firefly_account_id, "", ""
         );
 
         $this->assertEquals($expected, $actual);

--- a/tests/TransactionsToFireflySenderTest.php
+++ b/tests/TransactionsToFireflySenderTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\ConfigurationFactory;
 use App\TransactionsToFireflySender;
 use Fhp\Model\StatementOfAccount\Transaction;
 use PHPUnit\Framework\TestCase;
@@ -90,6 +91,52 @@ final class TransactionsToFireflySenderTest extends TestCase
         $actual   = TransactionsToFireflySender::transform_transaction_to_firefly_request_body(
             $transaction,
             $this->firefly_account_id, "", ""
+        );
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function test_transaction_processing_debit_regex()
+    {
+        $transaction = new Transaction;
+        $transaction->setAccountNumber($this->valid_iban);
+        $transaction->setCreditDebit(Transaction::CD_DEBIT);
+        $transaction->setValutaDate(new DateTime('2020-06-01'));
+        $transaction->setAmount(3.14);
+        $transaction->setName('destination_name');
+        $transaction->setStructuredDescription(array('SVWZ' => 'LASTSCHRIFT / BELASTUNGExample StoreKARTE 000000000KDN-REF 000000Ref. XXXX/0000', 'ABWA' => 'bakery'));
+
+        $configuration = ConfigurationFactory::load_from_file('data/configurations/example.json');
+
+        $exp_regex_match = '/^(Übertrag \/ Überweisung|Lastschrift \/ Belastung)(.*)(END-TO-END-REF.*|Karte.*|KFN.*)(Ref\..*)$/mi';
+        $exp_regex_replace = '$2 [$1 | $3 | $4]';
+
+        $this->assertEquals($exp_regex_match, $configuration->description_regex_match);
+        $this->assertEquals($exp_regex_replace, $configuration->description_regex_replace);
+
+        $expected = array(
+            'apply_rules' => true,
+            'error_if_duplicate_hash' => true,
+            'transactions' => array(
+                array(
+                    'type' => 'withdrawal',
+                    'date' => '2020-06-01',
+                    'amount' => 3.14,
+                    'description' => 'Example Store [LASTSCHRIFT / BELASTUNG | KARTE 000000000KDN-REF 000000 | Ref. XXXX/0000]',
+                    'source_name' => null,
+                    'source_id' => $this->firefly_account_id,
+                    'source_iban' => null,
+                    'destination_name' => 'destination_name',
+                    'destination_id' => null,
+                    'destination_iban' => $this->valid_iban,
+                    'sepa_ct_id' => '',
+                    'notes' => 'bakery',
+                )
+            )
+        );
+        $actual   = TransactionsToFireflySender::transform_transaction_to_firefly_request_body(
+            $transaction,
+            $this->firefly_account_id, $configuration->description_regex_match, $configuration->description_regex_replace
         );
 
         $this->assertEquals($expected, $actual);


### PR DESCRIPTION
I added some initial support to manipulate transaction descriptions via regular expressions.
One can specify a matching regex and a replacing regex either via config file or web form.
I extended the example and added a test case.

Idea from #29 