### PR TITLE
workaround: missing description and booking text in transaction

### DIFF
--- a/app/TransactionsToFireflySender.php
+++ b/app/TransactionsToFireflySender.php
@@ -88,6 +88,10 @@ class TransactionsToFireflySender
             $description = $transaction->getBookingText();
         }
 
+        if ($description == "") {
+            $description = $transaction->getDescription1();
+        }
+
         if($regex_match !== "" && $regex_replace !== "") {
             $description = preg_replace($regex_match, $regex_replace, $description);
         }


### PR DESCRIPTION
1st PR to fix #103 
If MainDescription and BookingText is not available for a transaction the Description1 is used as description for firefly iii import.
This is a example transaction where these information are missing:
```
{
   [
      "bookingDate":"protected"
   ]=> object(DateTime)#117 (3){
      [
         "date"
      ]=> string(26)"2023-05-30 00:00:00.000000"[
         "timezone_type"
      ]=> int(3)[
         "timezone"
      ]=> string(3)"UTC"
   }[
      "valutaDate":"protected"
   ]=> object(DateTime)#118 (3){
      [
         "date"
      ]=> string(26)"2023-05-29 00:00:00.000000"[
         "timezone_type"
      ]=> int(3)[
         "timezone"
      ]=> string(3)"UTC"
   }[
      "amount":"protected"
   ]=> float(1000)[
      "creditDebit":"protected"
   ]=> string(6)"credit"[
      "isStorno":"protected"
   ]"=> bool(false)"[
      "bookingCode":"protected"
   ]=> string(3)"166"[
      "bookingText":"protected"
   ]=> string(0)""[
      "description1":"protected"
   ]=> string(22)"EREF+CCB.147.UE.151999"[
      "description2":"protected"
   ]=> string(0)""[
      "structuredDescription":"protected"
   ]=> array(1){
      [
         "EREF"
      ]=> string(17)"CCB.147.UE.151999"
   }[
      "bankCode":"protected"
   ]=> string(0)""[
      "accountNumber":"protected"
   ]=> string(22)"DE93530800300777797800"[
      "name":"protected"
   ]=> string(35)"KLAUS DIETER WEBER ODER RENATE WEBE"[
      "booked":"protected"
   ]"=> bool(true)"[
      "pn":"protected"
   ]=> int(0)[
      "textKeyAddition":"protected"
   ]=> int(0)
}
```

Example Result with this PR.
![image](https://github.com/bnw/firefly-iii-fints-importer/assets/10805806/3bd872fa-cd62-47fc-ac19-04700e04f212)

