### PR TITLE
Allows to fully automate even if tan medium required

### DIFF
--- a/app/Choose2FADevice.php
+++ b/app/Choose2FADevice.php
@@ -8,7 +8,7 @@ use Symfony\Component\HttpFoundation\Session\Session;
 
 function Choose2FADevice()
 {
-    global $request, $session, $twig;
+    global $request, $session, $twig, $automate_without_js;
 
     $session->invalidate();
     $session->set('bank_username', $request->request->get('bank_username'));
@@ -28,6 +28,11 @@ function Choose2FADevice()
     if ($tan_mode->needsTanMedium()) {
         $tan_devices = $fin_ts->getTanMedia($tan_mode);
         if (count($tan_devices) == 1) {
+            if ($automate_without_js) {
+                $session->set('bank_2fa_device', $tan_devices[0]->getName());
+                return Step::STEP2_LOGIN;
+            }
+
             $auto_submit_form_via_js = true;
         } else {
             $auto_submit_form_via_js = false;

--- a/app/CollectData.php
+++ b/app/CollectData.php
@@ -25,10 +25,10 @@ function CollectData()
 
         if ($request->request->has('bank_username')) {
             $configuration->bank_username = $request->request->get('bank_username');
-        } 
+        }
         if ($request->request->has('bank_password')) {
             $configuration->bank_password = $request->request->get('bank_password');
-        }          
+        }
         if ($configuration->bank_username == "" || $configuration->bank_password == "") {
             echo $twig->render(
                 'collecting-data.twig',
@@ -61,6 +61,11 @@ function CollectData()
         if ($tan_mode->needsTanMedium()) {
             $tan_devices = $fin_ts->getTanMedia($tan_mode);
             if (count($tan_devices) == 1) {
+                if ($automate_without_js) {
+                    $session->set('bank_2fa_device', $tan_devices[0]->getName());
+                    return Step::STEP2_LOGIN;
+                }
+
                 $auto_skip_form = true;
             } else {
                 $auto_skip_form = false;


### PR DESCRIPTION
Hi,

I am not familiar with PHP and don't know if this is a good solution. However with this change I was able to fully automate the download from german DKB accounts which required to set up the TAN medium only once and then continues to work without 2FA.

I could imagine that there's error handling missing, but I am too unfamiliar with it to efficiently solve that. I think as a user I'd expect to get an error status, if automation does not work anymore and also that this is not implemented, yet.

It's even possible that the part in `Choose2FADevice.php` is counter-productive and should be removed.
