### PR TITLE
Implement email notification for TAN challenges during an automated run

### DIFF
--- a/app/ConfigurationFactory.php
+++ b/app/ConfigurationFactory.php
@@ -3,6 +3,18 @@
 
 namespace App;
 
+class EmailConfig {
+    public $enabled;
+    public $host;
+    public $port;
+    public $smtp_secure;
+    public $username;
+    public $password;
+    public $from;
+    public $to;
+    public $subject;
+}
+
 class Configuration {
     public $bank_username;
     public $bank_password;
@@ -21,6 +33,7 @@ class Configuration {
     public $description_regex_match;
     public $description_regex_replace;
     public $force_mt940;
+    public $email_config;
 }
 
 class ConfigurationFactory
@@ -57,6 +70,24 @@ class ConfigurationFactory
         $configuration->description_regex_match   = $contentArray["description_regex_match"];
         $configuration->description_regex_replace = $contentArray["description_regex_replace"];
         $configuration->force_mt940               = filter_var($contentArray["force_mt940"] ?? false, FILTER_VALIDATE_BOOLEAN);
+
+        $email_config = new EmailConfig();
+        $email_config->enabled = false;
+        if (isset($contentArray["tan_required_email_notification"])) {
+            $email_config->host        = $contentArray["tan_required_email_notification"]["host"];
+            $email_config->port        = $contentArray["tan_required_email_notification"]["port"];
+            $email_config->smtp_secure = $contentArray["tan_required_email_notification"]["smtp_secure"];
+            $email_config->username    = $contentArray["tan_required_email_notification"]["username"];
+            $email_config->password    = $contentArray["tan_required_email_notification"]["password"];
+            $email_config->from        = $contentArray["tan_required_email_notification"]["from"];
+            $email_config->to          = $contentArray["tan_required_email_notification"]["to"];
+            $email_config->subject     = $contentArray["tan_required_email_notification"]["subject"];
+            $email_config->enabled = !empty($email_config->host) && !empty($email_config->port) &&
+                                     !empty($email_config->smtp_secure) && !empty($email_config->username) &&
+                                     !empty($email_config->password) && !empty($email_config->from) &&
+                                     !empty($email_config->to) && !empty($email_config->subject);
+        }
+        $configuration->email_config = $email_config;
 
         return $configuration;
     }

--- a/app/Login.php
+++ b/app/Login.php
@@ -1,12 +1,15 @@
 <?php
 namespace App\StepFunction;
 
+use App\ConfigurationFactory;
 use App\FinTsFactory;
 use App\Logger;
 use App\Step;
 use App\TanHandler;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\PHPMailer\SMTP;
 
 function Login()
 {
@@ -34,7 +37,32 @@ function Login()
     );
 
     if ($login_handler->needs_tan()) {
-        $login_handler->pose_and_render_tan_challenge();
+        if ($automate_without_js)
+        {
+            $filename = $request->request->get('data_collect_mode');
+            $configuration = ConfigurationFactory::load_from_file($filename);
+            if ($configuration->email_config->enabled) {
+                $mail = new PHPMailer();
+                $mail->isSMTP();
+                $mail->SMTPDebug = SMTP::DEBUG_SERVER;
+                $mail->Host = $configuration->email_config->host;
+                $mail->Port = $configuration->email_config->port;
+                $mail->SMTPSecure = $configuration->email_config->smtp_secure;
+                $mail->SMTPAuth = true;
+                $mail->Username = $configuration->email_config->username;
+                $mail->Password = $configuration->email_config->password;
+                $mail->setFrom($configuration->email_config->from);
+                $mail->addAddress($configuration->email_config->to);
+                $mail->Subject = $configuration->email_config->subject;
+                $mail->Body = "A TAN is required";
+
+                if (!$mail->send()) {
+                    echo 'Mailer Error: ' . $mail->ErrorInfo;
+                }
+            }
+        } else {
+            $login_handler->pose_and_render_tan_challenge();
+        }
     } else {
         // Detect supported statement formats from BPD (now safely cached after login)
         $bpd = $fin_ts->getBpd();

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
     "phpseclib/bcmath_compat": "*",
     "ext-json": "*",
     "globalcitizen/php-iban": "^4.2",
-    "genkgo/camt": "^2.0"
+    "genkgo/camt": "^2.0",
+    "phpmailer/phpmailer": "^6.8"
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fb82a54c8950206b78752e72f0e7859a",
+    "content-hash": "f1f04f633fd209197cdfef9cebea4ee3",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -1439,6 +1439,87 @@
                 "source": "https://github.com/paragonie/random_compat"
             },
             "time": "2020-10-15T08:29:30+00:00"
+        },
+        {
+            "name": "phpmailer/phpmailer",
+            "version": "v6.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPMailer/PHPMailer.git",
+                "reference": "d1ac35d784bf9f5e61b424901d5a014967f15b12"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPMailer/PHPMailer/zipball/d1ac35d784bf9f5e61b424901d5a014967f15b12",
+                "reference": "d1ac35d784bf9f5e61b424901d5a014967f15b12",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-filter": "*",
+                "ext-hash": "*",
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "doctrine/annotations": "^1.2.6 || ^1.13.3",
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcompatibility/php-compatibility": "^9.3.5",
+                "roave/security-advisories": "dev-latest",
+                "squizlabs/php_codesniffer": "^3.7.2",
+                "yoast/phpunit-polyfills": "^1.0.4"
+            },
+            "suggest": {
+                "decomplexity/SendOauth2": "Adapter for using XOAUTH2 authentication",
+                "ext-mbstring": "Needed to send email in multibyte encoding charset or decode encoded addresses",
+                "ext-openssl": "Needed for secure SMTP sending and DKIM signing",
+                "greew/oauth2-azure-provider": "Needed for Microsoft Azure XOAUTH2 authentication",
+                "hayageek/oauth2-yahoo": "Needed for Yahoo XOAUTH2 authentication",
+                "league/oauth2-google": "Needed for Google XOAUTH2 authentication",
+                "psr/log": "For optional PSR-3 debug logging",
+                "symfony/polyfill-mbstring": "To support UTF-8 if the Mbstring PHP extension is not enabled (^1.2)",
+                "thenetworg/oauth2-azure": "Needed for Microsoft XOAUTH2 authentication"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPMailer\\PHPMailer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-only"
+            ],
+            "authors": [
+                {
+                    "name": "Marcus Bointon",
+                    "email": "phpmailer@synchromedia.co.uk"
+                },
+                {
+                    "name": "Jim Jagielski",
+                    "email": "jimjag@gmail.com"
+                },
+                {
+                    "name": "Andy Prevost",
+                    "email": "codeworxtech@users.sourceforge.net"
+                },
+                {
+                    "name": "Brent R. Matzelle"
+                }
+            ],
+            "description": "PHPMailer is a full-featured email creation and transfer class for PHP",
+            "support": {
+                "issues": "https://github.com/PHPMailer/PHPMailer/issues",
+                "source": "https://github.com/PHPMailer/PHPMailer/tree/v6.12.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Synchro",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-10-15T16:49:08+00:00"
         },
         {
             "name": "phpseclib/bcmath_compat",
@@ -4946,5 +5027,5 @@
         "ext-json": "*"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/data/configurations/example.json
+++ b/data/configurations/example.json
@@ -21,5 +21,17 @@
     "__from_to_comment__": "The following values will be passed directly into DateTime. Set them to null to choose them manually during import process.",
     "from": "now - 7 days",
     "to": "now"
+  },
+  "tan_required_email_notification":
+  {
+    "host": "smtp.gmail.com",
+    "port": "465",
+    "__smtp_secure_comment__": "either tls for STARTTLS or ssl for SMTPS",
+    "smtp_secure": "ssl",
+    "username": "",
+    "password": "",
+    "from": "",
+    "to": "",
+    "subject": "[Firefly III Fin-TS] A Tan is required"
   }
 }


### PR DESCRIPTION
During an headless import (GET Parameter `automate` and `config` set) it can happen that a TAN challenge is posed. In this case the user usually doesn't sit in front of the browser or terminal.

Therefore an email notification can help and this PR implements this.
The configuration required for this to work is in the `.json` under the `tan_required_email_notification` object (See `example.json`). All fields are required to be non empty, else the email notification won't be enabled.

Question:
1. I didn't want to save every email config entry in the session. Therefore I just reread the configuration file. Is this fine? 

solves #75