### PR TITLE
fix docs about disabling regex in example.json

### DIFF
--- a/data/configurations/example.json
+++ b/data/configurations/example.json
@@ -8,7 +8,7 @@
   "firefly_url": "",
   "firefly_access_token": "",
   "skip_transaction_review": "false",
-  "__description_regex_comment__": "To disable the regex search & replace of the transaction description, set them to null.",
+  "__description_regex_comment__": "To disable the regex search & replace of the transaction description, set both to an empty string.",
   "description_regex_match": "/^(Übertrag \\/ Überweisung|Lastschrift \\/ Belastung)(.*)(END-TO-END-REF.*|Karte.*|KFN.*)(Ref\\..*)$/mi",
   "description_regex_replace": "$2 [$1 | $3 | $4]",
   "auto_submit_form_via_js": false,


### PR DESCRIPTION
In https://github.com/bnw/firefly-iii-fints-importer/blob/0192cb8995c376e584dbeba3bc419fe662b1cb50/app/TransactionsToFireflySender.php#L95C1-L95C59, we check if both, `regex_match` and `regex_replace` are empty, not if they are `null`. Thus I propose to change the documentation inside `example.json`.