### PR TITLE
Enable encrypted password storage

### DIFF
--- a/app/CollectData.php
+++ b/app/CollectData.php
@@ -31,12 +31,20 @@ function CollectData()
         }      
 
         if (!empty($configuration->nonce)) {
-            $key = hex2bin($request->request->get('key'));
-            $nonce = hex2bin($configuration->nonce);
-            $encrypted_pwd = hex2bin($configuration->bank_password);
-            
-            $configuration->bank_password = sodium_crypto_aead_xchacha20poly1305_ietf_decrypt($encrypted_pwd, '', $nonce, $key);
-        }
+            if($request->request->has('key')) {
+                $key = hex2bin($request->request->get('key'));
+                $nonce = hex2bin($configuration->nonce);
+                $encrypted_pwd = hex2bin($configuration->bank_password);
+                
+                $configuration->bank_password = sodium_crypto_aead_xchacha20poly1305_ietf_decrypt($encrypted_pwd, '', $nonce, $key);
+            } else {
+                if ($request->request->has('bank_password')) {
+                    $configuration->bank_password = $request->request->get('bank_password');
+                } else {
+                    $configuration->bank_password = "";
+                }           
+            }
+       }
         
         if ($configuration->bank_username == "" || $configuration->bank_password == "") {
             echo $twig->render(

--- a/app/CollectData.php
+++ b/app/CollectData.php
@@ -31,7 +31,7 @@ function CollectData()
         }      
 
         if (!empty($configuration->nonce)) {
-            if($request->request->has('key')) {
+            if($request->request->has('key') && !empty($request->request->get('key'))) {
                 $key = hex2bin($request->request->get('key'));
                 $nonce = hex2bin($configuration->nonce);
                 $encrypted_pwd = hex2bin($configuration->bank_password);

--- a/app/ConfigurationFactory.php
+++ b/app/ConfigurationFactory.php
@@ -19,6 +19,7 @@ class Configuration {
     public $choose_account_to;
     public $description_regex_match;
     public $description_regex_replace;
+    public $nonce;
 }
 
 class ConfigurationFactory
@@ -51,7 +52,8 @@ class ConfigurationFactory
         }
         $configuration->description_regex_match   = $contentArray["description_regex_match"];
         $configuration->description_regex_replace = $contentArray["description_regex_replace"];
-
+        $configuration->nonce = $contentArray["nonce"];
+        
         return $configuration;
     }
 }

--- a/app/Encrypt.php
+++ b/app/Encrypt.php
@@ -20,6 +20,6 @@ function Encrypt()
             'nonce' => bin2hex($nonce),
             'key' => bin2hex($key)
         ));
-    
+    session_destroy();
     return Step::DONE;
 }

--- a/app/Encrypt.php
+++ b/app/Encrypt.php
@@ -1,0 +1,25 @@
+<?php
+namespace App\StepFunction;
+
+use App\Step;
+
+function Encrypt()
+{
+    global $twig, $session;
+    
+    
+    $nonce = \random_bytes(\SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES);
+    $pwd = $session->get('bank_password');
+    $key = hex2bin($session->get('key'));
+    
+    $pwd_encrypted = sodium_crypto_aead_xchacha20poly1305_ietf_encrypt($pwd, '', $nonce, $key);
+    echo $twig->render(
+        'encrypt.twig',
+        array(
+            'pwd_encrypted' => bin2hex($pwd_encrypted),
+            'nonce' => bin2hex($nonce),
+            'key' => bin2hex($key)
+        ));
+    
+    return Step::DONE;
+}

--- a/app/PwdInput.php
+++ b/app/PwdInput.php
@@ -1,0 +1,28 @@
+<?php
+namespace App\StepFunction;
+
+use App\Step;
+
+function PwdInput()
+{
+    global $twig, $request, $session;
+    
+    $key = sodium_crypto_aead_xchacha20poly1305_ietf_keygen();
+
+    if (!$request->request->has('bank_password')) {
+        $session->invalidate();
+        
+        echo $twig->render(
+            'pwd-input.twig',
+            array(
+                'key' => bin2hex($key),
+                'next_step' => Step::STEP_ENC0_INPUT,
+            ));
+        return;
+    } else {
+        $session->set('bank_password', $request->request->get('bank_password'));
+        $session->set('key', $request->request->get('key'));
+    }
+    
+    return Step::STEP_ENC1_RESULT;
+}

--- a/app/Setup.php
+++ b/app/Setup.php
@@ -8,7 +8,12 @@ function Setup()
     global $twig, $automate_without_js, $request;
 
     $requested_config_file = '';
-
+    $key = null;
+    
+    if (isset($_GET['key'])) {
+        $key = $_GET['key'];
+    } 
+   
     if (isset($_GET['config'])) {
         $filename = basename($_GET['config']);
         $requested_config_file = 'data/configurations/' . $filename;
@@ -26,6 +31,7 @@ function Setup()
         if ($automate_without_js)
         {
             $request->request->set('data_collect_mode', $requested_config_file);
+            $request->request->set('key', $key);
             return Step::STEP1_COLLECTING_DATA;
         }
     }
@@ -41,6 +47,7 @@ function Setup()
     echo $twig->render(
         'setup.twig',
         array(
+            'key' => $key,
             'files' => $configuration_files,
             'requested_config_file' => $requested_config_file,
             'next_step' => Step::STEP1_COLLECTING_DATA

--- a/app/Step.php
+++ b/app/Step.php
@@ -12,4 +12,7 @@ class Step extends \MyCLabs\Enum\Enum
     public const STEP4_GET_IMPORT_DATA = 'STEP4_GET_IMPORT_DATA';
     public const STEP5_RUN_IMPORT_BATCHED = 'STEP5_RUN_IMPORT_BATCHED';
     public const DONE = 'DONE';
+    
+    public const STEP_ENC0_INPUT = "ENC_INPUT";
+    public const STEP_ENC1_RESULT = "ENC_RESULT";
 }

--- a/app/index.php
+++ b/app/index.php
@@ -13,6 +13,8 @@ include 'Login.php';
 include 'ChooseAccount.php';
 include 'GetImportData.php';
 include 'RunImportBatched.php';
+include 'PwdInput.php';
+include 'Encrypt.php';
 
 use App\StepFunction;
 use App\FinTsFactory;
@@ -30,7 +32,11 @@ $automate_without_js = false;
 
 $request = Request::createFromGlobals();
 
-$current_step = new Step($request->request->get("step", Step::STEP0_SETUP));
+if (isset($_GET['generate'])) {
+    $current_step = new Step($request->request->get("step", Step::STEP_ENC0_INPUT));
+} else {
+    $current_step = new Step($request->request->get("step", Step::STEP0_SETUP));
+}
 
 $session = new Session();
 $session->start();
@@ -38,6 +44,8 @@ $session->start();
 if (isset($_GET['automate'])) {
     $automate_without_js = $_GET['automate'] == "true";
 }
+
+
 
 
 do
@@ -71,6 +79,14 @@ do
             $current_step = StepFunction\RunImportBatched();
             break;
 
+        case Step::STEP_ENC0_INPUT:
+            $current_step = StepFunction\PwdInput();
+            break;
+            
+        case Step::STEP_ENC1_RESULT:
+            $current_step = StepFunction\Encrypt();
+            break;
+            
         default:
             $current_step = Step::DONE;
             break;

--- a/app/public/html/collecting-data.twig
+++ b/app/public/html/collecting-data.twig
@@ -36,7 +36,7 @@
             </div>
             <div class="form-group">
                 <label for="bank_password">Password</label>
-                <input class="form-control" id="bank_password" name="bank_password" type="password" required>
+                <input class="form-control" id="bank_password" name="bank_password" type="password" required value="{{ configuration.bank_password }}">
                 <small class="form-text text-muted">This is NOT the PIN of your bank card!</small>
             </div>
             {% if configuration.bank_2fa == "" %}

--- a/app/public/html/encrypt.twig
+++ b/app/public/html/encrypt.twig
@@ -1,0 +1,20 @@
+{% extends 'base.twig' %}
+
+{% block title %}Encrypted Password{% endblock %}
+
+{% block content %}
+    <h1>Encryption Result</h1>
+    <p>
+        <h2>For the configuration file</h2>
+        <label for="pwd_encrypted">Encrypted password (bank_password)</label>
+        <input class="form-control" id="pwd_encrypted" name="bank_password" style="font-family:monospace;" value="{{ pwd_encrypted }}" disabled>
+        <label for="nonce">Nonce</label>
+        <input class="form-control" id="nonce" name="nonce" style="font-family:monospace;" value="{{ nonce }}" disabled>
+    </p>
+    <p>
+        <h2>The secret url argument</h2>
+        <label for="key">Key</label>
+        <input class="form-control" id="key" name="key" style="font-family:monospace;" value="{{ key }}" disabled>
+    </p>
+
+{% endblock %}

--- a/app/public/html/pwd-input.twig
+++ b/app/public/html/pwd-input.twig
@@ -15,7 +15,7 @@
             <label for="key">Key</label>
             <input class="form-control" id="key" name="key" value="{{ key }}" required style="font-family:monospace;">
             <small class="form-text text-muted">
-                Secret key to use. Use the generate one if unsure.
+                Secret key to use. Use the generate one if unsure. Should only be entered for using the same secret for multiple configurations.
             </small>
         </div>
         <button type="submit" class="btn btn-primary">Submit</button>

--- a/app/public/html/pwd-input.twig
+++ b/app/public/html/pwd-input.twig
@@ -1,0 +1,23 @@
+{% extends 'base.twig' %}
+
+{% block title %}Encrypted Password{% endblock %}
+
+{% block content %}
+    <h1>Enter the password to be encrypted.</h1>
+    <form action="." method="post">
+        <input type="hidden" name="step" value="{{ next_step }}">
+        <div class="form-group">
+            <label for="bank_password">Password</label>
+            <input class="form-control" id="bank_password" name="bank_password" required style="font-family:monospace;">
+            <small class="form-text text-muted">
+                Password for your bank account. This will not be stored.
+            </small>
+            <label for="key">Key</label>
+            <input class="form-control" id="key" name="key" value="{{ key }}" required style="font-family:monospace;">
+            <small class="form-text text-muted">
+                Secret key to use. Use the generate one if unsure.
+            </small>
+        </div>
+        <button type="submit" class="btn btn-primary">Submit</button>
+    </form>
+{% endblock %}

--- a/app/public/html/setup.twig
+++ b/app/public/html/setup.twig
@@ -15,6 +15,7 @@
 
     <form name="next-form" action="." method="post">
         <input type="hidden" name="step" value="{{ next_step }}">
+        <input type="hidden" name="key" value="{{ key }}">
         <fieldset class="mt-3">
             <div class="form-group">
                 <label for="data_collect_mode">Configuration</label>

--- a/data/configurations/example.json
+++ b/data/configurations/example.json
@@ -19,5 +19,7 @@
     "__from_to_comment__": "The following values will be passed directly into DateTime. Set them to null to choose them manually during import process.",
     "from": "now - 7 days",
     "to": "now"
-  }
+  },
+  "__nonce_comment__": "Encryption nonce. If set, bank_password is assumed to be encrypted with. Generate data with generate GET parameter. Key to be passed as key GET parameter",
+  "nonce": ""
 }


### PR DESCRIPTION
I was not comfortable with storing my password in plaintext on any server. Therefore, i created an encryption feature.

DISCLAIMER: I'm not an IT security expert and just implemented it using [a guide](https://php.watch/articles/modern-php-encryption-decryption-sodium#enable). Severe security vulnerabilities are likely.

Requires the sodium extension to be enabled (php core component)

It works as follows:
- Call index.php?generate to get into the generation frontend.
- Add results to the config file and store the secret key
- Call index.php?key=KEY for decrpytion

Considering my PHP knowledge is based on stack overflow and copy/paste, i assume quite a few "suboptimal" code pieces 😄 