### PR TITLE
Readme.md: Fix config GET param description and add curl/wget example

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -59,7 +59,9 @@ Headless usage
 -----
 This importer can be used without a browser (e.g. by using `curl` or `wget`). For this you have to specify two `GET` parameters:
 1. `automate=true`
-1. `config=data/configurations/example.json` where this path should be exactly the same one you see on the select box
+2. `config=example.json` where example.json is a config located in the "data/configurations" folder.
+3. Use `curl -X GET 'http://localhost:8080/?automate=true&config=example.json'` 
+4. or `wget -O - -q 'http://localhost:8080/?automate=true&config=example.json'` to run the importer.
 
 Additionally make sure that you filled out the `choose_account_automation` part in the config.  
 Thanks to [Bur0k](https://github.com/Bur0k) for this feature!


### PR DESCRIPTION
This pull request fixes a small mistake regarding the 'config' GET parameter. Only the filename, e.g., 'example.json,' is used by the app. The path to the file is removed by the 'basename()' function in 'Setup.php' https://github.com/bnw/firefly-iii-fints-importer/blob/0192cb8995c376e584dbeba3bc419fe662b1cb50/app/Setup.php#L13 and is, therefore, not needed.

Additionally, it adds examples of how to use the headless importer with 'curl' and 'wget'.