### PR TITLE
Fix/enable decoupled tan submission

### DIFF
--- a/app/public/html/collecting-data.twig
+++ b/app/public/html/collecting-data.twig
@@ -55,6 +55,7 @@
                     <option value="920">smsTAN (920)</option>
                     <option value="921">pushTAN (921)</option>                    
                     <option value="922">photoTAN (922)</option>
+                    <option value="923">pushTAN 2.0 (923)</option>
                     <option value="930">mobileTAN (930, for Postbank)</option>
                     <option value="942">mobileTAN (942)</option>
                     <option value="944">SecureGoTAN (944)</option>

--- a/app/public/html/tan-challenge.twig
+++ b/app/public/html/tan-challenge.twig
@@ -16,10 +16,12 @@
 
     <form action="." method="post">
         <input type="hidden" name="step" value="{{ next_step }}">
+        {% if not is_decoupled_tan_mode %}
         <div class="form-group">
             <label for="tan">TAN</label>
             <input class="form-control" id="tan" name="tan" required style="font-family:monospace;">
         </div>
+        {% endif %}
         <button type="submit" class="btn btn-primary">Submit</button>
     </form>
 {% endblock %}


### PR DESCRIPTION
Since I now also encounter the problem described in #131 I went ahead and tried to implement a solution.
This is my first time writing PHP code, so please forgive me for doing things unusually.

This adds the basic functionality for decoupled TAN checks, presented by phpFinTs.
I could confirm this working with my Sparkasse bank account.

However, this implementation has a caveat: Confirming the import in the pushTAN app is necessary every time an import is started. Also this adds an entry to the list of saved devices in device management (Geräteverwaltung).
This is also an issue in phpFinTs: nemiah/phpFinTS#453, where it is described as an issue with the "kundensystemId"