### PR TITLE
Enable FinTS persistence

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -53,6 +53,8 @@ Instead of entering all necessary account information every time, you can load i
 Simply create such a JSON-file in the `data/configurations` folder by adapting the provieded [`data/configurations/example.json`](data/configurations/example.json). When starting the app in your browser, you can then choose the JSON-file as a configuration source.  
 Please note that the `bank_2fa`-value in the JSON file corresponds to the number of the 2-factor authentication as listed in [`app/public/html/collecting-data.twig`](app/public/html/collecting-data.twig).  
 Thanks to [joBr99](https://github.com/joBr99) for this feature!
+If you need to enter a TAN on every import run, you can paste the persistence string you get presented after the import into the configuration file.
+Treat this string as a secret, as it provides access to your bank account without a TAN!
 
 
 Headless usage

--- a/app/CollectData.php
+++ b/app/CollectData.php
@@ -48,6 +48,9 @@ function CollectData()
         if($configuration->bank_2fa_device) {
             $session->set('bank_2fa_device',         $configuration->bank_2fa_device);
         }
+        if($configuration->bank_fints_persistence) {
+            $session->set('fints_persistence',   $configuration->bank_fints_persistence);
+        }
         $session->set('firefly_url',             $configuration->firefly_url);
         $session->set('firefly_access_token',    $configuration->firefly_access_token);
         $session->set('skip_transaction_review', $configuration->skip_transaction_review);

--- a/app/ConfigurationFactory.php
+++ b/app/ConfigurationFactory.php
@@ -10,6 +10,7 @@ class Configuration {
     public $bank_code;
     public $bank_2fa;
     public $bank_2fa_device;
+    public $bank_fints_persistence;
     public $firefly_url;
     public $firefly_access_token;
     public $skip_transaction_review;
@@ -35,6 +36,9 @@ class ConfigurationFactory
         $configuration->bank_code               = $contentArray["bank_code"];
         $configuration->bank_2fa                = $contentArray["bank_2fa"];
         $configuration->bank_2fa_device         = @$contentArray["bank_2fa_device"];
+        if (isset($contentArray["bank_fints_persistence"]) && $contentArray["bank_fints_persistence"] != '') {
+            $configuration->bank_fints_persistence = base64_decode($contentArray["bank_fints_persistence"]);
+        }
         $configuration->firefly_url             = $contentArray["firefly_url"];
         $configuration->firefly_access_token    = $contentArray["firefly_access_token"];
         $configuration->skip_transaction_review = filter_var($contentArray["skip_transaction_review"], FILTER_VALIDATE_BOOLEAN);

--- a/app/FinTsFactory.php
+++ b/app/FinTsFactory.php
@@ -24,9 +24,14 @@ class FinTsFactory
         $options->productVersion = '1.0';
         
         $credentials = Credentials::create($session->get('bank_username'), $session->get('bank_password'));
-        
-        $finTs = FinTs::new($options, $credentials);
-        
+        $fints_persistence = $session->get('fints_persistence');
+
+        if ($fints_persistence) {
+            $finTs = FinTs::new($options, $credentials, $fints_persistence);
+        } else {
+            $finTs = FinTs::new($options, $credentials);
+        }
+
         $tanMode = self::get_tan_mode($finTs, $session);
 
         if ($tanMode->needsTanMedium() and $session->has('bank_2fa_device')) {

--- a/app/GetImportData.php
+++ b/app/GetImportData.php
@@ -64,6 +64,7 @@ function GetImportData()
             )
         );
     }
+    $fin_ts->close();
     $session->set('persistedFints', $fin_ts->persist());
     return Step::DONE;
 }

--- a/app/Login.php
+++ b/app/Login.php
@@ -20,6 +20,8 @@ function Login()
     $login_handler = new TanHandler(
         function () {
             global $fin_ts;
+            // fresh start, forget any dialog that may have been persisted
+            $fin_ts->forgetDialog();
             return $fin_ts->login();
         },
         'login-action',

--- a/app/RunImportBatched.php
+++ b/app/RunImportBatched.php
@@ -52,7 +52,8 @@ function RunImportWithJS()
             'done.twig',
             array(
                 'import_messages' => $import_messages,
-                'total_num_transactions' => count($transactions)
+                'total_num_transactions' => count($transactions),
+                'fints_persistence' => base64_encode($session->get('persistedFints'))
             )
         );
         $session->invalidate();

--- a/app/public/html/done.twig
+++ b/app/public/html/done.twig
@@ -7,6 +7,13 @@
 
     <p>{{ total_num_transactions }} transactions have been sent to Firefly III.</p>
 
+    <p>
+        You had to grant access to this importer using your TAN-mode.
+        To use this granted access on subsequent imports, you can use this persistence string.
+        It should be treated as a secret and can be used on the json configuration file.
+        <pre>{{ fints_persistence }}</pre>
+    </p>
+
     {% if import_messages is not empty %}
         <div class="alert alert-warning">
             For {{ import_messages | length }} transactions, Firefly III reported some problems which are listed below. <br>

--- a/data/configurations/example.json
+++ b/data/configurations/example.json
@@ -5,6 +5,7 @@
   "bank_url": "https://hbci11.fiducia.de/cgi-bin/hbciservlet",
   "bank_2fa": "944",
   "bank_2fa_device": "",
+  "bank_fints_persistence": "",
   "firefly_url": "",
   "firefly_access_token": "",
   "skip_transaction_review": "false",


### PR DESCRIPTION
As discussed in #149, storing and loading the FinTS persistence string can prevent needing to enter a TAN on every import run. I also have this problem, since my Sparkasse switched to decoupled TAN submission (which I provided as a feature in #142 and #145).

This PR adds several things:
- It presents the base64 enconded persistence string  in the `Done` step at the end of an import run with a description to add it into the configuration.
- If the persistence string present in the JSON, it is decoded and loaded in the `CollectData` step and added to the constructor of the FinTS instance.
- Some description in the Readme in the configuration paragraph.

For me, this works so that I do not have to approve the importer again and again on every run.
I also verified that everything works in a freshly built docker image with the current `php-FintTS` version specified by composer.