### PR TITLE
Fix for DKB destination account name note missing

### DIFF
--- a/app/TransactionsToFireflySender.php
+++ b/app/TransactionsToFireflySender.php
@@ -116,7 +116,7 @@ class TransactionsToFireflySender
                     'destination_id' => $destination['id'] ?? null,
                     'destination_iban' => $destination['iban'] ?? null,
                     'sepa_ct_id' => $transaction->getEndToEndID() ?? null,
-                    'notes' => $transaction->getStructuredDescription()['ABWA'] ?? null,
+                    'notes' => $transaction->getStructuredDescription()['ABWA'] ?? $destination['name'] ?? null,
                 )
             )
         );


### PR DESCRIPTION
After having another look at #154 i found that the real problem is a bit different:

Firefly uses the IBAN to uniquely identify accounts, but this is in fact not correct. It happens quite often that multiple accounts use the same IBAN (i assume payment providers?). Before, that was not an issue because the DKB transaction note contained the real destination account name. This is the same as with my other bank. Therefore, rules could be triggered based on the note, instead of the destination account name. The new DKB FinTs server does not provide the destination account note anymore.

This "fix" defaults the note to the destination account name, making DKB work as before and inline with my other bank.

.. However, i understand that this may be a controversial change. Let me know if you want to go ahead.

Sidenote: This also fixes some issues with #155. The account will still be wrong, but you can use rules again to sort transactions.