### PR TITLE
Add a config entry to force MT940

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -95,3 +95,4 @@ Bank specifics
 * For ING DiBa you need a password that is between 5 and 10 characters, not less not more as you will otherwise run into this error:
   * ```Anmeldung nur mit 10-stelliger Kontonummer und 5 bis 10-stelliger PIN möglich.```
   * *Note: this will not lead to your account being blocked due to to many attempts as you do not attempt a login funnily enough*
+* For Targobank, if your transactions are having [unhelpful descriptions](https://github.com/bnw/firefly-iii-fints-importer/pull/201), try setting `force_mt940=true` (only available in the configuration file, not the GUI). This will use a different API to retrieve your transactions that does not have this problem.

--- a/app/Choose2FADevice.php
+++ b/app/Choose2FADevice.php
@@ -22,6 +22,7 @@ function Choose2FADevice()
     $session->set('skip_transaction_review', $request->request->get('skip_transaction_review'));
     $session->set('description_regex_match', $request->request->get('description_regex_match'));
     $session->set('description_regex_replace', $request->request->get('description_regex_replace'));
+    $session->set('force_mt940', $request->request->get('force_mt940'));
     $fin_ts   = FinTsFactory::create_from_session($session);
     $tan_mode = FinTsFactory::get_tan_mode($fin_ts, $session);
 

--- a/app/CollectData.php
+++ b/app/CollectData.php
@@ -60,6 +60,7 @@ function CollectData()
         $session->set('choose_account_to',       $configuration->choose_account_to);
         $session->set('description_regex_match', $configuration->description_regex_match);
         $session->set('description_regex_replace', $configuration->description_regex_replace);
+        $session->set('force_mt940',             $configuration->force_mt940);
 
         $fin_ts   = FinTsFactory::create_from_session($session);
         $tan_mode = FinTsFactory::get_tan_mode($fin_ts, $session);

--- a/app/ConfigurationFactory.php
+++ b/app/ConfigurationFactory.php
@@ -20,6 +20,7 @@ class Configuration {
     public $choose_account_to;
     public $description_regex_match;
     public $description_regex_replace;
+    public $force_mt940;
 }
 
 class ConfigurationFactory
@@ -55,6 +56,7 @@ class ConfigurationFactory
         }
         $configuration->description_regex_match   = $contentArray["description_regex_match"];
         $configuration->description_regex_replace = $contentArray["description_regex_replace"];
+        $configuration->force_mt940               = filter_var($contentArray["force_mt940"] ?? false, FILTER_VALIDATE_BOOLEAN);
 
         return $configuration;
     }

--- a/app/Login.php
+++ b/app/Login.php
@@ -52,6 +52,11 @@ function Login()
             $session->set('statement_format', 'camt'); // Default, let exception handling deal with it
         }
 
+        if ($session->get('force_mt940')) {
+            Logger::info("Forcing MT940 format as per configuration");
+            $session->set('statement_format', 'mt940');
+        }
+
         if ($automate_without_js)
         {
             $session->set('persistedFints', $fin_ts->persist());

--- a/data/configurations/example.json
+++ b/data/configurations/example.json
@@ -13,6 +13,7 @@
   "description_regex_match": "/^(Übertrag \\/ Überweisung|Lastschrift \\/ Belastung)(.*)(END-TO-END-REF.*|Karte.*|KFN.*)(Ref\\..*)$/mi",
   "description_regex_replace": "$2 [$1 | $3 | $4]",
   "auto_submit_form_via_js": false,
+  "force_mt940": false,
   "choose_account_automation":
   {
     "bank_account_iban": "",


### PR DESCRIPTION
This PR adds a new config entry to force the use of MT940 instead of CAMT.

My bank (Targobank) gives problems me problems with the content of the CAMT fields. Sometimes they are populated, most of the time not.
Mostly they are stuck directly in a single field `RmtInf`:
```
                <NtryDtls>
                    <TxDtls>
                        <RltdPties>
                            <Cdtr>
                                <Nm></Nm>
                            </Cdtr>
                        </RltdPties>
                        <RmtInf>
                            <Ustrd>SEPA LASTSCHRIFT</Ustrd>
                            <Ustrd>PayPal Europe S.a.r.l. et Cie S.C.A</Ustrd>
                            <Ustrd>XXXXXXXXX/PP.1637.PP/. Foobar, Ihr Einkauf bei</Ustrd>
                            <Ustrd>Foobar</Ustrd>
                            <Ustrd>Kundenreferenz: 1047XXXXXXXX</Ustrd>
                            <Ustrd>Gläubiger-ID : LU9XXXXXXX</Ustrd>
                            <Ustrd>Mandat: 5CXXXXXXXXX</Ustrd>
                            <Ustrd>IBAN: LU8XXXXXXXX</Ustrd>
                        </RmtInf>
                    </TxDtls>
                </NtryDtls>
```