### PR TITLE
Fix to display full description on Targobank

### DIFF
--- a/app/StatementOfAccountHelper.php
+++ b/app/StatementOfAccountHelper.php
@@ -175,23 +175,25 @@ class StatementOfAccountHelper
                     $existingDesc['CURR'] = $currencyCode;
                     $transaction->setStructuredDescription($existingDesc);
 
-                    // Set booking text from entry-level additional info
-                    $additionalInfo = $entry->getAdditionalInfo();
-                    if ($additionalInfo) {
-                        $transaction->setBookingText($additionalInfo);
-                    }
-
-                    // Set description1 as additional fallback (use counterparty name or additional info)
-                    $description1 = '';
+                    // Use unstructured blocks for booking info
+                    $bookingText = '';
                     if ($detail && $detail->getRemittanceInformation()) {
                         // Try to get unstructured remittance info blocks as fallback
                         $unstructuredBlocks = $detail->getRemittanceInformation()->getUnstructuredBlocks();
                         if (!empty($unstructuredBlocks)) {
-                            $description1 = $unstructuredBlocks[0]->getMessage();
+                            foreach($unstructuredBlocks as $unstructuredBlock) {
+                                $bookingText = $bookingText . ' ' . $unstructuredBlock->getMessage();
+                            }
                         }
                     }
-                    if (empty($description1) && $additionalInfo) {
-                        $description1 = $additionalInfo;
+                    if (!empty($bookingText)) {
+                        $transaction->setBookingText($bookingText);
+                    }
+
+                    // Set description1 to additional info as fallback for booking info
+                    $description1 = $entry->getAdditionalInfo();
+                    if (!$description1) {
+                        $description1 = $bookingText;
                     }
                     if (!empty($description1)) {
                         $transaction->setDescription1($description1);

--- a/app/TransactionsToFireflySender.php
+++ b/app/TransactionsToFireflySender.php
@@ -87,9 +87,9 @@ class TransactionsToFireflySender
         }
         $firefly_accounts->rewind();
 
-        $description = $transaction->getMainDescription();
+        $description = $transaction->getBookingText();
         if ($description == "") {
-            $description = $transaction->getBookingText();
+            $description = $transaction->getMainDescription();
         }
 
         if ($description == "") {


### PR DESCRIPTION
Fix for this:
<img width="1191" height="770" alt="Image" src="https://github.com/user-attachments/assets/ffae725c-5da1-402e-81e3-e9dc79f179d2" />

Targobank splits the description over multiple blocks, this fix concatenates them into one string. It also prioritizes the unstructured blocks as the description over the structured data and additional info. Additional info is just as useless in the Targobank response and the underlying library used for parsing CAMT messages uses just the first block of the unstructured blocks for the `message` parameter of RemittanceInformation which is used here as the "MainDescription". 

If anyone comes by this PR and uses a different Bank than Targobank, please try this and let me know if there are any unwanted side effects!