### PR TITLE
feat: support multiple sequential description replacement rules

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -42,8 +42,11 @@ Tips
 -----
 * Banks typically only allow you to access the last two years worth of transactions.
   In order to ensure that your bank account shows the correct balance in Firefly III, even if not all of it's history can be imported, adjust the account's starting balance accordingly in Firefly III.
-* There is the option to reformat the description of a transaction, before it is sent to Firefly III.
-  This can be done by configuring a RegEx search and replace pair. See [data/configurations/example.json](https://github.com/bnw/firefly-iii-fints-importer/blob/master/data/configurations/example.json) or the [corresponding unit test](https://github.com/bnw/firefly-iii-fints-importer/blob/master/tests/TransactionsToFireflySenderTest.php) for an example. Thanks to [dfunke](https://github.com/dfunke) for this feature!
+* There is the option to reformat the description of a transaction before it is sent to Firefly III. This can be done by configuring a single RegEx pair or an array of multiple replacement rules:
+    * **Single Rule (Legacy):** Configure `description_regex_match` and `description_regex_replace`. This pair takes precedence over the multiple rules array if both are set.
+    * **Multiple Rules:** Define an array called `description_replacement_rules` in your configuration for sequential processing. It supports both RegEx patterns (e.g., `"/pattern/i"`) and simple string replacements.
+  
+  See [data/configurations/example.json](https://github.com/bnw/firefly-iii-fints-importer/blob/master/data/configurations/example.json) or the [corresponding unit test](https://github.com/bnw/firefly-iii-fints-importer/blob/master/tests/TransactionsToFireflySenderTest.php) for practical examples of both methods. Thanks to [dfunke](https://github.com/dfunke) for the initial RegEx feature and the subsequent enhancements!
 
 
 Storing configurations

--- a/app/CollectData.php
+++ b/app/CollectData.php
@@ -40,27 +40,28 @@ function CollectData()
             return;
         }
 
-        $session->set('bank_username',           $configuration->bank_username);
-        $session->set('bank_password',           $configuration->bank_password);
-        $session->set('bank_url',                $configuration->bank_url);
-        $session->set('bank_code',               $configuration->bank_code);
-        $session->set('bank_2fa',                $configuration->bank_2fa);
+        $session->set('bank_username', $configuration->bank_username);
+        $session->set('bank_password', $configuration->bank_password);
+        $session->set('bank_url', $configuration->bank_url);
+        $session->set('bank_code', $configuration->bank_code);
+        $session->set('bank_2fa', $configuration->bank_2fa);
         if($configuration->bank_2fa_device) {
-            $session->set('bank_2fa_device',         $configuration->bank_2fa_device);
+            $session->set('bank_2fa_device', $configuration->bank_2fa_device);
         }
         if($configuration->bank_fints_persistence) {
             $session->set('fints_persistence',   $configuration->bank_fints_persistence);
         }
-        $session->set('firefly_url',             $configuration->firefly_url);
-        $session->set('firefly_access_token',    $configuration->firefly_access_token);
+        $session->set('firefly_url', $configuration->firefly_url);
+        $session->set('firefly_access_token', $configuration->firefly_access_token);
         $session->set('skip_transaction_review', $configuration->skip_transaction_review);
-        $session->set('bank_account_iban' ,      $configuration->bank_account_iban);
-        $session->set('firefly_account_id',      $configuration->firefly_account_id);
-        $session->set('choose_account_from' ,    $configuration->choose_account_from);
-        $session->set('choose_account_to',       $configuration->choose_account_to);
+        $session->set('bank_account_iban', $configuration->bank_account_iban);
+        $session->set('firefly_account_id', $configuration->firefly_account_id);
+        $session->set('choose_account_from', $configuration->choose_account_from);
+        $session->set('choose_account_to', $configuration->choose_account_to);
         $session->set('description_regex_match', $configuration->description_regex_match);
         $session->set('description_regex_replace', $configuration->description_regex_replace);
-        $session->set('force_mt940',             $configuration->force_mt940);
+        $session->set('description_replacement_rules', $configuration->description_replacement_rules);
+        $session->set('force_mt940', $configuration->force_mt940);
 
         $fin_ts   = FinTsFactory::create_from_session($session);
         $tan_mode = FinTsFactory::get_tan_mode($fin_ts, $session);

--- a/app/ConfigurationFactory.php
+++ b/app/ConfigurationFactory.php
@@ -20,6 +20,7 @@ class Configuration {
     public $choose_account_to;
     public $description_regex_match;
     public $description_regex_replace;
+    public $description_replacement_rules;
     public $force_mt940;
 }
 
@@ -54,9 +55,10 @@ class ConfigurationFactory
             $configuration->choose_account_from = NULL;
             $configuration->choose_account_to = NULL;
         }
-        $configuration->description_regex_match   = $contentArray["description_regex_match"];
-        $configuration->description_regex_replace = $contentArray["description_regex_replace"];
-        $configuration->force_mt940               = filter_var($contentArray["force_mt940"] ?? false, FILTER_VALIDATE_BOOLEAN);
+        $configuration->description_regex_match       = $contentArray["description_regex_match"] ?? "";
+        $configuration->description_regex_replace     = $contentArray["description_regex_replace"] ?? "";
+        $configuration->description_replacement_rules = $contentArray["description_replacement_rules"] ?? [];
+        $configuration->force_mt940                   = filter_var($contentArray["force_mt940"] ?? false, FILTER_VALIDATE_BOOLEAN);
 
         return $configuration;
     }

--- a/app/RunImportBatched.php
+++ b/app/RunImportBatched.php
@@ -17,8 +17,9 @@ function RunImport($transactions)
         $session->get('firefly_url'),
         $session->get('firefly_access_token'),
         $session->get('firefly_account'),
-        $session->get('description_regex_match', ""),
-        $session->get('description_regex_replace', "")
+        $session->get('description_regex_match') ?? "",
+        $session->get('description_regex_replace') ?? "",
+        $session->get('description_replacement_rules') ?? []
     );
     $result = $sender->send_transactions();
     if (is_array($result)) {

--- a/app/TransactionsToFireflySender.php
+++ b/app/TransactionsToFireflySender.php
@@ -50,7 +50,9 @@ class TransactionsToFireflySender
         Transaction $transaction,
         int $firefly_account_id,
         GetAccountsResponse $firefly_accounts,
-        string $regex_match, string $regex_replace
+        string $regex_match,
+        string $regex_replace,
+        array $regex_rules = []
     )
     {
         $debitOrCredit = $transaction->getCreditDebit();
@@ -87,24 +89,54 @@ class TransactionsToFireflySender
         }
         $firefly_accounts->rewind();
 
-        $description = $transaction->getMainDescription();
-        if ($description == "") {
-            $description = $transaction->getBookingText();
-        }
+        // Get initial description from transaction
+        $description = $transaction->getMainDescription() ?: $transaction->getBookingText() ?: $transaction->getDescription1() ?: "";
 
-        if ($description == "") {
-            $description = $transaction->getDescription1();
-        }
+        // Apply transformation rules
+        if (!empty($description)) {
+            
+            // Priority: regex_match/replace (legacy) takes precedence if provided, 
+            // otherwise use the new multiple rules array.
+            if (!empty($regex_match) && !empty($regex_replace)) {
+                $activeRules = [['from' => $regex_match, 'to' => $regex_replace]];
+            } else {
+                $activeRules = $regex_rules;
+            }
+            
+            foreach ($activeRules as $rule) {
+                $from = $rule['from'] ?? '';
+                $to   = $rule['to'] ?? '';
+                
+                if ($from === '') continue;
 
-        if (!empty($regex_match) && !empty($regex_replace) && !empty($description)) {
-            $result = preg_replace($regex_match, $regex_replace, $description);
-            if ($result !== null) {
-                $description = $result;
+                // Check if it's a Regex (starts/ends with same non-alphanumeric delimiter)
+                $is_regex = preg_match('/^([^\w\s]).*?\1[imsxuADU]*$/', $from);
+
+                if ($is_regex) {
+                    $result = @preg_replace($from, $to, $description);
+                    if ($result !== null) {
+                        if ($result !== $description) {
+                            Logger::debug("Regex replacement applied: '$description' -> '$result'");
+                            $description = $result;
+                        }
+                    } elseif (preg_last_error() !== PREG_NO_ERROR) {
+                        Logger::error("Invalid Regex pattern or error: '$from' (Error code: " . preg_last_error() . ")");
+                    }
+                } else {
+                    $old_description = $description;
+                    $description = str_ireplace($from, $to, $description);
+                    if ($old_description !== $description) {
+                        Logger::debug("String replacement applied: '$old_description' -> '$description'");
+                    }
+                }
+
+                if (empty($description)) break;
             }
         }
 
-        if($description == null) {
-            throw new \Exception("Error in regular expression!\nMatch expression {$regex_match}\nReplace expression {$regex_replace}");
+        // Final safety check
+        if ($description === null) {
+             throw new \Exception("Error in description transformation!");
         }
 
         // Get currency code from structured description (set by CAMT parser)

--- a/data/configurations/example.json
+++ b/data/configurations/example.json
@@ -12,6 +12,16 @@
   "__description_regex_comment__": "To disable the regex search & replace of the transaction description, set both to an empty string.",
   "description_regex_match": "/^(Übertrag \\/ Überweisung|Lastschrift \\/ Belastung)(.*)(END-TO-END-REF.*|Karte.*|KFN.*)(Ref\\..*)$/mi",
   "description_regex_replace": "$2 [$1 | $3 | $4]",
+  "description_replacement_rules": [
+    {
+      "from": "/^(Übertrag \\/ Überweisung|Lastschrift \\/ Belastung)(.*)(END-TO-END-REF.*|Karte.*|KFN.*)(Ref\\..*)$/mi",
+      "to": "$2 [$1 | $3 | $4]"
+    },
+    {
+      "from": "GUTSCHR. UEBERW. DAUERAUFTR",
+      "to": "DAUERAUFTRAG"
+    }
+  ],
   "auto_submit_form_via_js": false,
   "force_mt940": false,
   "choose_account_automation":

--- a/tests/TransactionsToFireflySenderTest.php
+++ b/tests/TransactionsToFireflySenderTest.php
@@ -95,7 +95,7 @@ final class TransactionsToFireflySenderTest extends TestCase
         );
         $actual   = TransactionsToFireflySender::transform_transaction_to_firefly_request_body(
             $transaction,
-            $this->firefly_account_id, $this->firefly_accounts, "", ""
+            $this->firefly_account_id, $this->firefly_accounts, "", "", []
         );
 
         $this->assertEquals($expected, $actual);
@@ -129,7 +129,7 @@ final class TransactionsToFireflySenderTest extends TestCase
         );
         $actual   = TransactionsToFireflySender::transform_transaction_to_firefly_request_body(
             $transaction,
-            $this->firefly_account_id, $this->firefly_accounts, "", ""
+            $this->firefly_account_id, $this->firefly_accounts, "", "", []
         );
 
         $this->assertEquals($expected, $actual);
@@ -161,7 +161,7 @@ final class TransactionsToFireflySenderTest extends TestCase
         );
         $actual   = TransactionsToFireflySender::transform_transaction_to_firefly_request_body(
             $transaction,
-            $this->firefly_account_id, $this->firefly_accounts, "", ""
+            $this->firefly_account_id, $this->firefly_accounts, "", "", []
         );
 
         $this->assertEquals($expected, $actual);
@@ -193,7 +193,7 @@ final class TransactionsToFireflySenderTest extends TestCase
         );
         $actual   = TransactionsToFireflySender::transform_transaction_to_firefly_request_body(
             $transaction,
-            $this->firefly_account_id, $this->firefly_accounts, "", ""
+            $this->firefly_account_id, $this->firefly_accounts, "", "", []
         );
 
         $this->assertEquals($expected, $actual);
@@ -241,7 +241,11 @@ final class TransactionsToFireflySenderTest extends TestCase
         );
         $actual   = TransactionsToFireflySender::transform_transaction_to_firefly_request_body(
             $transaction,
-            $this->firefly_account_id, $this->firefly_accounts, $configuration->description_regex_match, $configuration->description_regex_replace
+            $this->firefly_account_id,
+            $this->firefly_accounts,
+            $configuration->description_regex_match,
+            $configuration->description_regex_replace,
+            []
         );
 
         $this->assertEquals($expected, $actual);
@@ -260,13 +264,49 @@ final class TransactionsToFireflySenderTest extends TestCase
         $regex_match = '/^(Übertrag \/ Überweisung|Lastschrift \/ Belastung)(.*)(END-TO-END-REF.*|Karte.*|KFN.*)(Ref\..*)$'; // not a valid PHP regex, missing / at the end
         $regex_replace = '$2 [$1 | $3 | $4]';
 
-        set_error_handler(function() { /* ignore errors */ }); // required to suppress E_WARNING from preg_replace and test for an exception being thrown
-        $this->expectException(Exception::class);
-        $actual   = TransactionsToFireflySender::transform_transaction_to_firefly_request_body(
+        $actual = TransactionsToFireflySender::transform_transaction_to_firefly_request_body(
             $transaction,
-            $this->firefly_account_id, $this->firefly_accounts, $regex_match, $regex_replace
+            $this->firefly_account_id,
+            $this->firefly_accounts,
+            $regex_match,
+            $regex_replace,
+            []
         );
-        restore_error_handler();
+        $this->assertNotEmpty($actual['transactions'][0]['description']);
+    }
+
+    public function test_transaction_processing_multiple_rules()
+    {
+        $transaction = new Transaction;
+        $transaction->setAccountNumber($this->valid_iban);
+        $transaction->setCreditDebit(Transaction::CD_DEBIT);
+        $transaction->setValutaDate(new DateTime('2026-03-17'));
+        $transaction->setAmount(50.00);
+        $transaction->setName('Bank Service');
+        $transaction->setStructuredDescription(array('SVWZ' => 'GUTSCHR. UEBERW. DAUERAUFTR'));
+
+        $rules = [
+            [
+                'from' => '/^GUTSCHR\. UEBERW\. /i', 
+                'to'   => ''
+            ],
+            [
+                'from' => 'DAUERAUFTR', 
+                'to'   => 'DAUERAUFTRAG'
+            ]
+        ];
+        $expected_description = 'DAUERAUFTRAG';
+
+        $actual = TransactionsToFireflySender::transform_transaction_to_firefly_request_body(
+            $transaction,
+            $this->firefly_account_id, 
+            $this->firefly_accounts, 
+            "",
+            "",
+            $rules
+        );
+
+        $this->assertEquals($expected_description, $actual['transactions'][0]['description']);
     }
 
 }


### PR DESCRIPTION
### Summary
This PR enhances the transaction description transformation logic. While previously only a single RegEx pair was supported, users can now define an array of multiple replacement rules that are processed sequentially. This allows for complex "cleaning" of bank transaction texts (e.g., removing generic prefixes first, then fixing specific abbreviations).

### Changes
* **Sequential Processing:** Added `description_replacement_rules` (array) to the configuration.
* **Dual Support:** Supports both PHP RegEx (detected by delimiters like `/.../`) and simple case-insensitive string replacements.
* **Backward Compatibility:** Existing `description_regex_match` and `description_regex_replace` settings still work and take precedence over the new array to ensure no breaking changes for current users.
* **Robustness:** Added `@preg_replace` error handling to prevent the importer from crashing on invalid user-provided patterns.
* **Documentation:** Updated `README.md` and `example.json` with practical examples.
* **Testing:** Added a new unit test case for multiple sequential rules.

### How to use (Example)
In your `config.json` or via the session configuration:
```json
"description_replacement_rules": [
    {
        "from": "/^GUTSCHR\\. UEBERW\\. /i",
        "to": ""
    },
    {
        "from": "DAUERAUFTR",
        "to": "DAUERAUFTRAG"
    }
]