### PR TITLE
Fix processing of camt transactions when counterparty is empty

### DIFF
--- a/app/StatementOfAccountHelper.php
+++ b/app/StatementOfAccountHelper.php
@@ -119,7 +119,11 @@ class StatementOfAccountHelper
                             $name = $partyType->getName();
                             if ($name) {
                                 $transaction->setName($name);
+                            } else {
+                                $transaction->setName("");
                             }
+                        } else {
+                            $transaction->setName("");
                         }
 
                         // Handle single-party transactions where bank only provides one party (yourself)


### PR DESCRIPTION
This should fix https://github.com/bnw/firefly-iii-fints-importer/issues/220

When no counterparty is in transaction data, then we need at least an empty string, otherwise the frontend crashes while showing the transactions