### PR TITLE
Add support for excluding transactions by iban or pattern

### DIFF
--- a/app/CollectData.php
+++ b/app/CollectData.php
@@ -61,6 +61,8 @@ function CollectData()
         $session->set('description_regex_match', $configuration->description_regex_match);
         $session->set('description_regex_replace', $configuration->description_regex_replace);
         $session->set('force_mt940',             $configuration->force_mt940);
+        $session->set('exclude_regex_matchers',  $configuration->exclude_regex_matchers);
+        $session->set('exclude_ibans',           $configuration->exclude_ibans);
 
         $fin_ts   = FinTsFactory::create_from_session($session);
         $tan_mode = FinTsFactory::get_tan_mode($fin_ts, $session);

--- a/app/ConfigurationFactory.php
+++ b/app/ConfigurationFactory.php
@@ -21,6 +21,8 @@ class Configuration {
     public $description_regex_match;
     public $description_regex_replace;
     public $force_mt940;
+    public $exclude_regex_matchers;
+    public $exclude_ibans;
 }
 
 class ConfigurationFactory
@@ -57,6 +59,8 @@ class ConfigurationFactory
         $configuration->description_regex_match   = $contentArray["description_regex_match"];
         $configuration->description_regex_replace = $contentArray["description_regex_replace"];
         $configuration->force_mt940               = filter_var($contentArray["force_mt940"] ?? false, FILTER_VALIDATE_BOOLEAN);
+        $configuration->exclude_regex_matchers    = $contentArray["exclude_regex_matchers"] ?? [];
+        $configuration->exclude_ibans             = $contentArray["exclude_ibans"] ?? [];
 
         return $configuration;
     }

--- a/app/GetImportData.php
+++ b/app/GetImportData.php
@@ -5,7 +5,40 @@ use App\FinTsFactory;
 use App\Logger;
 use App\Step;
 use App\TanHandler;
+use Fhp\Model\StatementOfAccount\Transaction;
 use Fhp\Protocol\UnexpectedResponseException;
+
+// ExtTransactions to show if a transaction is excluded in frontend
+class ExtTransaction extends Transaction {
+    protected string $excluded;
+
+    public function __construct(Transaction $base) {
+        // Kopiere alle Eigenschaften vom Original ins neue Objekt
+        foreach (get_object_vars($base) as $key => $value) {
+            $this->$key = $value;
+        }
+    }
+
+    public function isExcluded(): bool
+    {
+        if ($this->excluded) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public function getExcluded(): string
+    {
+        return $this->excluded;
+    }
+
+    public function setExcluded(string $excluded): static
+    {
+        $this->excluded = $excluded;
+        return $this;
+    }
+}
 
 function GetImportData()
 {
@@ -25,6 +58,9 @@ function GetImportData()
         $statement_format = $session->get('statement_format', 'camt');
     }
     Logger::info("Using statement format: {$statement_format}");
+
+    $exclude_regex_matchers = $session->get('exclude_regex_matchers', []);
+    $exclude_ibans = $session->get('exclude_ibans', []);
 
     try {
         $soa_handler = new TanHandler(
@@ -91,6 +127,37 @@ function GetImportData()
                 Logger::info("No transactions found for date range: {$date_from} to {$date_to}");
             }
 
+            $ext_transactions = [];
+            foreach ($transactions as $key => $transaction) {
+                $ext_transaction = new ExtTransaction($transaction);
+                $ext_transaction->setExcluded(False);
+
+                if ($ext_transaction->isExcluded() == false) {
+                    $acc_number = $transaction->getAccountNumber();
+                    foreach ($exclude_ibans as $exclude_iban) {
+                        if ($exclude_iban === $acc_number) {
+                            Logger::trace("Exclude IBAN found: {$exclude_iban}. This transaction will not be sent");
+                            unset($transactions[$key]);
+                            $ext_transaction->setExcluded("IBAN: " . $exclude_iban);
+                            break;
+                        }
+                    }
+                }
+
+                if ($ext_transaction->isExcluded() == false) {
+                    $desc = $transaction->getMainDescription();
+                    foreach ($exclude_regex_matchers as $exclude_regex_matcher) {
+                        if (preg_match($exclude_regex_matcher, $desc)) {
+                            Logger::trace("Exclude match found: {$exclude_regex_matcher} <-> {$desc}. This transaction will not be sent");
+                            unset($transactions[$key]);
+                            $ext_transaction->setExcluded("Pattern: " . $exclude_regex_matcher);
+                            break;
+                        }
+                    }
+                }
+                $ext_transactions[] = $ext_transaction;
+            }
+
             // Clear fallback flag on success
             $session->remove('use_mt940_format');
 
@@ -108,7 +175,7 @@ function GetImportData()
             echo $twig->render(
                 'show-transactions.twig',
                 array(
-                    'transactions' => $transactions,
+                    'transactions' => $ext_transactions,
                     'next_step' => $next_step,
                     'skip_transaction_review' => $session->get('skip_transaction_review')
                 )

--- a/app/public/html/show-transactions.twig
+++ b/app/public/html/show-transactions.twig
@@ -35,6 +35,9 @@
                 </strong>
                 {% if transaction.getCreditDebit == 'debit' %}to{% else %}from{% endif %}
                 {{ transaction.getName() }}
+                <strong>
+                {% if transaction.isExcluded %} Excluded by {{ transaction.getExcluded }} {% endif %}
+                </strong>
             </div>
             <ul class="list-group list-group-flush">
                 <li class="list-group-item">

--- a/data/configurations/example.json
+++ b/data/configurations/example.json
@@ -21,5 +21,11 @@
     "__from_to_comment__": "The following values will be passed directly into DateTime. Set them to null to choose them manually during import process.",
     "from": "now - 7 days",
     "to": "now"
-  }
+  },
+  "exclude_regex_matchers": [
+    "/Example matcher that will most likely never match/"
+  ],
+  "exclude_ibans": [
+    "DE12345678909876543210"
+  ]
 }


### PR DESCRIPTION
I had the problem that many of my transfers did not match and will be included to firefly 2 times.

With that it is possible to exclude transactions by iban or description pattern.