### PR TITLE
fix: correct merchant name for DKB VISA card transactions

### DIFF
--- a/app/StatementOfAccountHelper.php
+++ b/app/StatementOfAccountHelper.php
@@ -43,6 +43,7 @@ class StatementOfAccountHelper
                 foreach ($record->getEntries() as $entry) {
                     // Create a new Transaction object
                     $transaction = new Transaction();
+                    $transaction->setName('');
 
                     // Set credit/debit indicator
                     $cdIndicator = $entry->getCreditDebitIndicator();
@@ -115,11 +116,7 @@ class StatementOfAccountHelper
 
                         // Set counterparty name
                         if ($relatedParty && $relatedParty->getRelatedPartyType()) {
-                            $partyType = $relatedParty->getRelatedPartyType();
-                            $name = $partyType->getName();
-                            if ($name) {
-                                $transaction->setName($name);
-                            }
+                            $transaction->setName($relatedParty->getRelatedPartyType()->getName() ?? '');
                         }
 
                         // Handle single-party transactions where bank only provides one party (yourself)

--- a/app/TransactionsToFireflySender.php
+++ b/app/TransactionsToFireflySender.php
@@ -56,7 +56,8 @@ class TransactionsToFireflySender
         $debitOrCredit = $transaction->getCreditDebit();
         $amount        = $transaction->getAmount();
         $source        = array('id' => $firefly_account_id);
-        $destination   = array('iban' => self::get_iban($transaction), 'name' => $transaction->getName());
+        $rawName       = $transaction->getName();
+        $destination   = array('iban' => self::get_iban($transaction), 'name' => ($rawName !== '') ? $rawName : null);
 
         Logger::trace("Transfer detection - counterparty IBAN: " . ($destination['iban'] ?? 'null') . ", name: " . ($destination['name'] ?? 'null') . ", source account ID: $firefly_account_id");
 
@@ -123,7 +124,10 @@ class TransactionsToFireflySender
             'source_iban' => $source['iban'] ?? null,
             'destination_name' => $destination['name'] ?? null,
             'destination_id' => $destination['id'] ?? null,
-            'destination_iban' => $destination['iban'] ?? null,
+            // Don't send destination_iban for withdrawals: card transactions share one IBAN
+            // (the card account), causing Firefly to merge all merchants into one expense account.
+            // For deposits and transfers destination_id is used instead, so iban is irrelevant.
+            'destination_iban' => ($type === TransactionType::WITHDRAWAL) ? null : ($destination['iban'] ?? null),
             'sepa_ct_id' => $transaction->getEndToEndID() ?: null,
             'notes' => $structuredDesc['ABWA'] ?? $destination['name'] ?? null,
         ], fn($value) => $value !== null);


### PR DESCRIPTION
## Summary

Fixes #232

DKB VISA card transactions were incorrectly assigned the merchant name of the first card transaction for all subsequent card transactions.

### Root causes (three layered bugs)

**1. Empty string passing through `array_filter` (MT940 path)**
When a card transaction has no merchant name, the MT940 parser calls `setName('')`. The `array_filter` only removed `null` values, so `destination_name: ""` was sent to Firefly III, which then fell back to a previously-used expense account.

**Fix:** Convert empty string from `getName()` to `null` in `TransactionsToFireflySender` so the field is omitted entirely from the API request.

**2. Uninitialized typed property (CAMT path, PHP 8.4)**
When no related party was present in CAMT data, `setName()` was never called. In PHP 8.4 accessing an uninitialized typed `string` property throws a Fatal Error.

**Fix:** Initialize `$name` to `''` immediately after `new Transaction()` in the CAMT parser, and always call `setName()` unconditionally (with `?? ''` fallback).

**3. Shared card IBAN causing all merchants to merge into one expense account**
All DKB VISA card transactions share the same `destination_iban` (the card account's virtual IBAN `DE96120300009005290904`). Firefly III matches expense accounts by IBAN first — so the first card transaction created an expense account with that IBAN, and every subsequent card transaction was merged into it, ignoring the actual `destination_name`.

**Fix:** Omit `destination_iban` for withdrawals. Expense accounts should be matched by name only; including a shared card IBAN causes all merchants to collapse into a single account.

## Test plan

- [ ] Import DKB VISA card transactions via FinTS
- [ ] Verify each card transaction is assigned to its own correctly-named expense account in Firefly III
- [ ] Verify non-card transactions (SEPA transfers, deposits) still import correctly
- [ ] Verify transfer detection (between own accounts) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)