### PR TITLE
Initialize transaction names and omit IBAN for withdrawals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor
 data
 !data/configurations/example.json
 .idea
+.DS_Store

--- a/app/StatementOfAccountHelper.php
+++ b/app/StatementOfAccountHelper.php
@@ -43,6 +43,7 @@ class StatementOfAccountHelper
                 foreach ($record->getEntries() as $entry) {
                     // Create a new Transaction object
                     $transaction = new Transaction();
+                    $transaction->setName('');
 
                     // Set credit/debit indicator
                     $cdIndicator = $entry->getCreditDebitIndicator();
@@ -115,11 +116,7 @@ class StatementOfAccountHelper
 
                         // Set counterparty name
                         if ($relatedParty && $relatedParty->getRelatedPartyType()) {
-                            $partyType = $relatedParty->getRelatedPartyType();
-                            $name = $partyType->getName();
-                            if ($name) {
-                                $transaction->setName($name);
-                            }
+                            $transaction->setName($relatedParty->getRelatedPartyType()->getName() ?? '');
                         }
 
                         // Handle single-party transactions where bank only provides one party (yourself)

--- a/app/TransactionsToFireflySender.php
+++ b/app/TransactionsToFireflySender.php
@@ -56,7 +56,8 @@ class TransactionsToFireflySender
         $debitOrCredit = $transaction->getCreditDebit();
         $amount        = $transaction->getAmount();
         $source        = array('id' => $firefly_account_id);
-        $destination   = array('iban' => self::get_iban($transaction), 'name' => $transaction->getName());
+        $rawName       = $transaction->getName();
+        $destination   = array('iban' => self::get_iban($transaction), 'name' => ($rawName !== '') ? $rawName : null);
 
         Logger::trace("Transfer detection - counterparty IBAN: " . ($destination['iban'] ?? 'null') . ", name: " . ($destination['name'] ?? 'null') . ", source account ID: $firefly_account_id");
 
@@ -123,7 +124,10 @@ class TransactionsToFireflySender
             'source_iban' => $source['iban'] ?? null,
             'destination_name' => $destination['name'] ?? null,
             'destination_id' => $destination['id'] ?? null,
-            'destination_iban' => $destination['iban'] ?? null,
+            // Don't send destination_iban for withdrawals: card transactions share one IBAN
+            // (the card account), causing Firefly to merge all merchants into one expense account.
+            // For deposits and transfers destination_id is used instead, so iban is irrelevant.
+            'destination_iban' => ($type === TransactionType::WITHDRAWAL) ? null : ($destination['iban'] ?? null),
             'sepa_ct_id' => $transaction->getEndToEndID() ?: null,
             'notes' => $structuredDesc['ABWA'] ?? $destination['name'] ?? null,
         ], fn($value) => $value !== null);


### PR DESCRIPTION
This pull request improves the handling of transaction party names and destination IBANs when parsing and transforming transaction data for Firefly. The main focus is on ensuring that empty or missing names are handled gracefully and that IBANs are not incorrectly merged for card withdrawals.

**Transaction Name Handling:**

* Ensures that the `Transaction` object's name is always set to a string (never left uninitialized), defaulting to an empty string if no name is available. [[1]](diffhunk://#diff-01254678a1d80247dafb297217f4edcab50c0cdd38865b6b6cf68bb8f032a9e3R46) [[2]](diffhunk://#diff-01254678a1d80247dafb297217f4edcab50c0cdd38865b6b6cf68bb8f032a9e3L118-R119)
* When transforming transactions, sets the destination name to `null` if the name is an empty string, preventing empty names from being sent to Firefly.

**Destination IBAN Handling:**

* Modifies the request body to omit the `destination_iban` field for withdrawals (e.g., card transactions), preventing Firefly from merging all merchants into a single expense account due to shared IBANs. For other transaction types, the IBAN is included as before.Ensure Transaction objects always have a name initialized (set to empty string) and simplify assigning related party names with a null-coalescing call. When preparing destination data for Firefly, send null instead of an empty name and omit destination_iban for withdrawal transactions to avoid merging merchants (card accounts share a single IBAN). This prevents accidental grouping in Firefly while preserving IDs for deposits/transfers.

This fixes Issue #232 