### PR TITLE
Fix: decoupled TAN polling no longer triggers a fresh login per check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,10 @@ vendor
 data
 !data/configurations/example.json
 .idea
+
+# Local test runner for our docker-based test environment (not part of bnw's official tooling)
+/run-tests.sh
+
+# Artifact left by tests/TransactionsToFireflySenderTest.php (pre-existing baseline issue, unrelated to this fix)
+/test_example.json
+

--- a/app/TanHandler.php
+++ b/app/TanHandler.php
@@ -37,8 +37,22 @@ class TanHandler
             $this->action = unserialize($this->session->get($this->action_id));
             $this->session->remove($this->action_id);
             if ($this->fin_ts->getSelectedTanMode()->isDecoupled()) {
-                if ($this->action->getTanRequest() != null && !$this->fin_ts->checkDecoupledSubmission($this->action)) {
-                    $this->action = ($this->create_action_lambda)();
+                if ($this->action->getTanRequest() != null) {
+                    // For decoupled TAN modes (e.g. DKB pushTAN 940), the
+                    // user confirms the TAN in their bank's mobile app.
+                    // checkDecoupledSubmission() polls the bank for the
+                    // confirmation, advances the action's state in place,
+                    // and returns true once the confirmation has arrived.
+                    //
+                    // Critically, we must NOT re-create the action via
+                    // create_action_lambda here if it's still pending — that
+                    // would call $fin_ts->login() again and generate a
+                    // brand-new TAN challenge at the bank, leading to
+                    // rate-limit lockouts (e.g. DKB error 9040
+                    // "Authorization method is locked because too many
+                    // challenges were requested"). See bnw#230, #227, #183
+                    // and phpFinTS#535 for the canonical resolution.
+                    $this->fin_ts->checkDecoupledSubmission($this->action);
                 }
             } else {
                 $this->fin_ts->submitTan($this->action, $this->request->request->get('tan'));

--- a/tests/TanHandlerTest.php
+++ b/tests/TanHandlerTest.php
@@ -1,0 +1,210 @@
+<?php
+
+use App\Step;
+use App\TanHandler;
+use Fhp\BaseAction;
+use Fhp\FinTs;
+use Fhp\Model\TanRequest;
+use Fhp\Model\TanMode;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+
+/**
+ * Named fixture: a TanRequest that survives serialize/unserialize.
+ * Anonymous classes can't be reconstructed after unserialize, so we use
+ * a concrete named class here.
+ */
+final class FixtureTanRequest implements TanRequest
+{
+    public function getProcessId(): string { return 'process-id'; }
+    public function getChallenge(): ?string { return 'challenge-text'; }
+    public function getTanMediumName(): ?string { return null; }
+    public function getChallengeHhdUc(): ?\Fhp\Syntax\Bin { return null; }
+}
+
+/**
+ * Named fixture BaseAction subclass that:
+ *   - has a non-null tanRequest (matches "TAN was asked, not yet confirmed")
+ *   - reports needsTan() = true
+ *   - is serialize/unserialize friendly (named, no closures)
+ */
+final class FixturePendingTanAction extends BaseAction
+{
+    public function __construct()
+    {
+        $this->tanRequest = new FixtureTanRequest();
+    }
+    public function needsTan(): bool { return true; }
+    protected function createRequest(\Fhp\Protocol\BPD $bpd, ?\Fhp\Protocol\UPD $upd) { return []; }
+}
+
+/**
+ * Tests TanHandler's decoupled-TAN handling.
+ *
+ * Bug being fixed: when a decoupled TAN mode (e.g. DKB pushTAN 940) is still
+ * pending user confirmation on their phone, bnw's create_or_continue_action()
+ * RE-CREATES the action by re-invoking the `create_action_lambda`. That
+ * lambda calls $fin_ts->login() which initiates a brand-new dialog with the
+ * bank, which sends a brand-new TAN challenge to the user's phone. Repeat
+ * this and the bank rate-limits ("Authorization method is locked because
+ * too many challenges were requested" — DKB error 9040). The fix is to
+ * NOT re-create the action; just keep it, so the caller can re-render the
+ * "waiting for TAN confirmation" page.
+ *
+ * See bnw/firefly-iii-fints-importer#230, #227, #183, and phpFinTS#535's
+ * resolution (needsPollingWait()-based pattern).
+ */
+final class TanHandlerTest extends TestCase
+{
+    /** Build the boilerplate Session/Twig/Request/Step dependencies that
+     * TanHandler needs but doesn't actually exercise in these tests. */
+    private function fakeSession(): Session
+    {
+        return new Session(new MockArraySessionStorage());
+    }
+
+    private function fakeTwig(): Environment
+    {
+        // ArrayLoader lets us render anything without filesystem templates.
+        return new Environment(new ArrayLoader([]));
+    }
+
+    private function fakeRequest(): Request
+    {
+        return new Request();
+    }
+
+    private function fakeStep(): Step
+    {
+        return new Step(Step::STEP2_LOGIN);
+    }
+
+    /**
+     * The bug: when we have a previously-saved decoupled action waiting for
+     * confirmation, and the user hasn't tapped approve yet, TanHandler used
+     * to re-run the action lambda — effectively doing a fresh login() and
+     * generating a NEW TAN challenge to the bank.
+     *
+     * Desired behavior: lambda is NOT called. The pending action stays as
+     * the current action and the caller re-renders the waiting UI.
+     */
+    public function test_decoupled_pending_does_not_recreate_action(): void
+    {
+        // Named, serialize-safe fixture: TAN asked, user hasn't confirmed.
+        $action = new FixturePendingTanAction();
+
+        $session = $this->fakeSession();
+        $session->set('login-action', serialize($action));
+
+        // FinTs mock: decoupled TAN mode, checkDecoupledSubmission returns
+        // false (user hasn't confirmed yet).
+        $tanMode = $this->createMock(TanMode::class);
+        $tanMode->method('isDecoupled')->willReturn(true);
+
+        $finTs = $this->createMock(FinTs::class);
+        $finTs->method('getSelectedTanMode')->willReturn($tanMode);
+        $finTs->method('checkDecoupledSubmission')->willReturn(false);
+
+        // Count lambda invocations. The fix means it must be 0.
+        $lambdaCalls = 0;
+        $lambda = function () use (&$lambdaCalls, $action) {
+            $lambdaCalls++;
+            return $action;
+        };
+
+        new TanHandler(
+            $lambda,
+            'login-action',
+            $session,
+            $this->fakeTwig(),
+            $finTs,
+            $this->fakeStep(),
+            $this->fakeRequest(),
+        );
+
+        $this->assertSame(
+            0, $lambdaCalls,
+            "Pending decoupled TAN must NOT trigger a fresh login() — that " .
+            "would generate a brand-new TAN challenge at the bank and lead " .
+            "to rate-limit lockouts (e.g. DKB error 9040)."
+        );
+    }
+
+    /**
+     * Baseline behavior we must NOT break: when there's no saved action in
+     * the session at all (fresh wizard start), the lambda IS invoked once
+     * to create the initial action.
+     */
+    public function test_fresh_session_calls_lambda_once(): void
+    {
+        $session = $this->fakeSession();
+
+        $finTs = $this->createMock(FinTs::class);
+
+        $lambdaCalls = 0;
+        $action = $this->createMock(BaseAction::class);
+        $lambda = function () use (&$lambdaCalls, $action) {
+            $lambdaCalls++;
+            return $action;
+        };
+
+        new TanHandler(
+            $lambda,
+            'login-action',
+            $session,
+            $this->fakeTwig(),
+            $finTs,
+            $this->fakeStep(),
+            $this->fakeRequest(),
+        );
+
+        $this->assertSame(1, $lambdaCalls, "Fresh session must call lambda exactly once.");
+    }
+
+    /**
+     * Non-decoupled TAN handling must continue to work: if the saved action
+     * is non-decoupled (the user typed a TAN into the form), TanHandler
+     * should submit that TAN to FinTs::submitTan and NOT recreate the action.
+     */
+    public function test_non_decoupled_submits_tan_and_keeps_action(): void
+    {
+        $action = $this->createMock(BaseAction::class);
+
+        $session = $this->fakeSession();
+        $session->set('login-action', serialize($action));
+
+        $tanMode = $this->createMock(TanMode::class);
+        $tanMode->method('isDecoupled')->willReturn(false);
+
+        $request = new Request();
+        $request->request->set('tan', '123456');
+
+        $finTs = $this->createMock(FinTs::class);
+        $finTs->method('getSelectedTanMode')->willReturn($tanMode);
+        $finTs->expects($this->once())
+            ->method('submitTan')
+            ->with($this->isInstanceOf(BaseAction::class), '123456');
+
+        $lambdaCalls = 0;
+        $lambda = function () use (&$lambdaCalls, $action) {
+            $lambdaCalls++;
+            return $action;
+        };
+
+        new TanHandler(
+            $lambda,
+            'login-action',
+            $session,
+            $this->fakeTwig(),
+            $finTs,
+            $this->fakeStep(),
+            $request,
+        );
+
+        $this->assertSame(0, $lambdaCalls, "Non-decoupled TAN path must not call the action lambda.");
+    }
+}


### PR DESCRIPTION
Fixes #230, #227, and resolves the root cause behind #183.

## Bug

When a decoupled TAN mode (e.g. DKB pushTAN 940, Sparkasse pushTAN, Comdirect pushTAN, …) is still pending user confirmation on their phone, `TanHandler::create_or_continue_action()` was **re-creating the action** by re-invoking the `create_action_lambda` whenever `checkDecoupledSubmission()` returned `false`. The lambda calls `FinTs::login()` (or the equivalent for non-login actions), which initiates a brand-new dialog with the bank, which generates a **brand-new TAN challenge** to the user's phone.

Symptoms:
- Each poll for "did the user tap approve yet?" results in another TAN challenge.
- After only a few polls the bank rate-limits the TAN method (DKB returns error `9040 Authorization method is locked because too many challenges were requested`).
- In severe cases the entire mobile-app session is invalidated and the user has to re-enter all credentials to recover.

## Fix

When `checkDecoupledSubmission()` returns `false`, keep the saved action as-is. The phpFinTS API contract is that this method *updates the action's `TanRequest` in place* to reflect the latest state, so the caller can simply re-render the \"waiting for TAN\" page on the next request without re-triggering anything at the bank. See [nemiah/phpFinTS#535](https://github.com/nemiah/phpFinTS/issues/535) — its resolution explicitly describes this pattern.

The non-decoupled path (`FinTs::submitTan()` with a typed TAN) is untouched.

## Tests

New unit tests in `tests/TanHandlerTest.php` cover:

1. **`test_decoupled_pending_does_not_recreate_action`** — the regression test that captures the bug. With the old code, `create_action_lambda` is invoked → counter is 1 → test fails. With this PR, counter is 0 → test passes.
2. **`test_fresh_session_calls_lambda_once`** — baseline: on the first wizard step (no saved action in session), the lambda IS invoked exactly once. Guards against breaking the initial-login path.
3. **`test_non_decoupled_submits_tan_and_keeps_action`** — regression guard for the SMS-TAN / photoTAN paths, which always worked. We verify `FinTs::submitTan()` is still called with the user-supplied TAN.

All existing tests in `TransactionsToFireflySenderTest` continue to pass. (`test_transaction_processing_debit_incorrect_regex` was already failing on master before this PR; not addressed here.)

## Verified against live DKB

I verified the fix against my own DKB-Cash account (TAN mode 940, pushTAN via the DKB-App), specifically the failure scenario from #230:

1. Cleared `bank_fints_persistence` to force a fresh login.
2. Wizard → entered PIN → submitted → received **one** push notification on the DKB-App.
3. **Without tapping approve**, clicked Submit on the wizard's TAN-challenge page.
4. With the old code: the bank would have sent a second push (the bug).
5. **With this PR: no second push.** The wizard re-rendered the TAN page once.
6. Tapped approve on the DKB-App → clicked Submit again → wizard proceeded normally through account selection → statement import.

Total TAN cost: **1**, exactly as intended.

## Notes on a related, separate issue

While testing I noticed that the on-screen `fints_persistence` blob displayed at the end of a successful import is **deterministically truncated** for DKB (the wire-format string of the `HICAZSv1` segment claims `s:136` but only 40 bytes are emitted, so subsequent attempts to reload via `FinTs::new(..., $persistedInstance)` fail at `unserialize`). That looks like a phpFinTS bug, not a bnw bug — I'll file it upstream separately. It does not affect this PR.