### PR TITLE
Fix: auto-save FinTS persistence to loaded config + copy-friendly UI (fixes truncation root-cause for nemiah/phpFinTS#564)

### DIFF
--- a/app/CollectData.php
+++ b/app/CollectData.php
@@ -18,7 +18,15 @@ function CollectData()
                 'next_step' => Step::STEP1p5_CHOOSE_2FA_DEVICE
             ));
     } else {
+        // bnw#236 follow-up: Setup.php stashed the config-file path here so
+        // RunImportBatched can write the refreshed persistence back to it
+        // after the import. invalidate() below wipes the whole session — so
+        // capture the value and restore it right after.
+        $savedConfigurationFileName = $session->get('configurationFileName');
         $session->invalidate();
+        if ($savedConfigurationFileName) {
+            $session->set('configurationFileName', $savedConfigurationFileName);
+        }
 
         $filename = $request->request->get('data_collect_mode');
         $configuration = ConfigurationFactory::load_from_file($filename);

--- a/app/ConfigurationFactory.php
+++ b/app/ConfigurationFactory.php
@@ -119,6 +119,16 @@ class ConfigurationFactory
             );
         }
 
+        // Preserve the existing file's permissions across the atomic rename.
+        // Config files often hold plaintext bank credentials + Firefly tokens,
+        // and operators may chmod them to 0600. file_put_contents on the .tmp
+        // uses the process umask (typically 0644); without this chmod the
+        // rename would silently relax those permissions.
+        $origPerms = @fileperms($fileName);
+        if ($origPerms !== false) {
+            @chmod($tmp, $origPerms & 0777);
+        }
+
         if (!rename($tmp, $fileName)) {
             // Best-effort cleanup; don't mask the original error.
             @unlink($tmp);

--- a/app/ConfigurationFactory.php
+++ b/app/ConfigurationFactory.php
@@ -60,4 +60,71 @@ class ConfigurationFactory
 
         return $configuration;
     }
+
+    /**
+     * Update only the `bank_fints_persistence` key inside an existing
+     * configuration JSON file, preserving every other top-level key and
+     * every nested object (e.g. `choose_account_automation`).
+     *
+     * The file is written atomically: contents go to `<fileName>.tmp` first
+     * and are then `rename()`d into place. The temporary file is removed if
+     * anything goes wrong.
+     *
+     * Throws `\RuntimeException` if the existing file is missing or contains
+     * invalid JSON — we deliberately refuse to overwrite a malformed file,
+     * because doing so would silently destroy whatever the user has there.
+     *
+     * Passing an empty `$base64String` is a deliberate clear and writes an
+     * empty string into `bank_fints_persistence` (it is NOT skipped).
+     *
+     * @param string $fileName     Absolute or relative path to an existing JSON config.
+     * @param string $base64String The new base64-encoded phpFinTS persistence blob.
+     * @throws \RuntimeException
+     */
+    static function save_persistence_to_file($fileName, $base64String)
+    {
+        if (!file_exists($fileName)) {
+            throw new \RuntimeException(
+                "Cannot save FinTS persistence: configuration file does not exist: $fileName"
+            );
+        }
+
+        $existing = file_get_contents($fileName);
+        if ($existing === false) {
+            throw new \RuntimeException(
+                "Cannot save FinTS persistence: failed to read configuration file: $fileName"
+            );
+        }
+
+        $contentArray = json_decode($existing, true);
+        if (!is_array($contentArray)) {
+            throw new \RuntimeException(
+                "Cannot save FinTS persistence: existing configuration file is not valid JSON: $fileName"
+            );
+        }
+
+        $contentArray["bank_fints_persistence"] = $base64String;
+
+        $encoded = json_encode($contentArray, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        if ($encoded === false) {
+            throw new \RuntimeException(
+                "Cannot save FinTS persistence: failed to encode JSON for: $fileName"
+            );
+        }
+
+        $tmp = $fileName . '.tmp';
+        if (file_put_contents($tmp, $encoded) === false) {
+            throw new \RuntimeException(
+                "Cannot save FinTS persistence: failed to write temporary file: $tmp"
+            );
+        }
+
+        if (!rename($tmp, $fileName)) {
+            // Best-effort cleanup; don't mask the original error.
+            @unlink($tmp);
+            throw new \RuntimeException(
+                "Cannot save FinTS persistence: failed to rename $tmp to $fileName"
+            );
+        }
+    }
 }

--- a/app/RunImportBatched.php
+++ b/app/RunImportBatched.php
@@ -41,10 +41,18 @@ function RunImportWithJS()
 {
     global $session, $twig, $num_transactions_to_import_at_once;
 
-    assert($session->has('transactions_to_import'));
-    assert($session->has('num_transactions_processed'));
-    assert($session->has('import_messages'));
-    assert($session->has('firefly_account'));
+    // bnw quirk (independent of bnw#236): when GetImportData fetches an empty
+    // result (no new transactions in the requested window), these session
+    // keys are never set, and the original asserts crash with PHP fatal.
+    // Default to "nothing to do" so done.twig still renders + auto-save can
+    // still write back the freshly-captured persistence.
+    if (!$session->has('transactions_to_import'))    $session->set('transactions_to_import',    serialize(array()));
+    if (!$session->has('num_transactions_processed')) $session->set('num_transactions_processed', 0);
+    if (!$session->has('import_messages'))            $session->set('import_messages',            serialize(array()));
+    // tolerate missing firefly_account too — bnw's ChooseAccount can fail to
+    // set it when the configured IBAN doesn't match a discovered account; we
+    // still want done.twig to render so the captured persistence is saved.
+    if (!$session->has('firefly_account'))            $session->set('firefly_account', null);
     $transactions                = unserialize($session->get('transactions_to_import'));
     $num_transactions_processed  = $session->get('num_transactions_processed');
     $import_messages             = unserialize($session->get('import_messages'));
@@ -85,8 +93,12 @@ function RunImportWithoutJS()
 {
     global $session, $twig;
 
-    assert($session->has('transactions_to_import'));
-    assert($session->has('firefly_account'));
+    // Same defensive defaults as WithJS — bnw's GetImportData skips setting
+    // these keys when the result is empty, and ChooseAccount can fail to set
+    // firefly_account if the configured IBAN doesn't match any discovered
+    // account. Don't crash — render done.twig (with auto-save) anyway.
+    if (!$session->has('transactions_to_import')) $session->set('transactions_to_import', serialize(array()));
+    if (!$session->has('firefly_account'))        $session->set('firefly_account', null);
     $transactions = unserialize($session->get('transactions_to_import'));
 
     if (empty($transactions)) {
@@ -133,6 +145,17 @@ function try_save_persistence($session, $base64String)
 {
     if (!$session->has('configurationFileName')) {
         return null;
+    }
+    // Defense: never overwrite a saved persistence with empty/junk. If the
+    // session got wiped before we got here (e.g., a prior crash invalidated
+    // it), persistedFints will be empty and the base64-encoded form ends up
+    // as the encoding of an empty string. Refuse to write that.
+    if (empty($base64String) || strlen($base64String) < 32) {
+        return array(
+            'ok'       => false,
+            'fileName' => basename($session->get('configurationFileName')),
+            'error'    => 'refused to write empty/short persistence (session was wiped before save)',
+        );
     }
     $fileName = $session->get('configurationFileName');
     try {

--- a/app/RunImportBatched.php
+++ b/app/RunImportBatched.php
@@ -1,6 +1,7 @@
 <?php
 namespace App\StepFunction;
 
+use App\ConfigurationFactory;
 use App\TransactionsToFireflySender;
 use App\Step;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -48,12 +49,15 @@ function RunImportWithJS()
     $num_transactions_processed  = $session->get('num_transactions_processed');
     $import_messages             = unserialize($session->get('import_messages'));
     if ($num_transactions_processed >= count($transactions)) {
+        $fintsPersistence = base64_encode($session->get('persistedFints'));
+        $autoSaveStatus   = try_save_persistence($session, $fintsPersistence);
         echo $twig->render(
             'done.twig',
             array(
                 'import_messages' => $import_messages,
                 'total_num_transactions' => count($transactions),
-                'fints_persistence' => base64_encode($session->get('persistedFints'))
+                'fints_persistence' => $fintsPersistence,
+                'auto_save_status' => $autoSaveStatus
             )
         );
         $session->invalidate();
@@ -98,15 +102,49 @@ function RunImportWithoutJS()
             $import_messages = array_merge($import_messages, $result);
         }
     }
+    $fintsPersistence = base64_encode($session->get('persistedFints'));
+    $autoSaveStatus   = try_save_persistence($session, $fintsPersistence);
     echo $twig->render(
         'done.twig',
         array(
             'import_messages' => $import_messages,
-            'total_num_transactions' => count($transactions)
+            'total_num_transactions' => count($transactions),
+            'fints_persistence' => $fintsPersistence,
+            'auto_save_status' => $autoSaveStatus
         )
     );
     $session->invalidate();
     return Step::DONE;
+}
+
+/**
+ * If the user loaded a configuration file at the start of this run
+ * (Setup.php stored the resolved path in the session), try to write the
+ * fresh FinTS persistence blob back into that file. Returns null when no
+ * config file is known (fresh interactive run), an array with ok=true on
+ * success, or ok=false with the error message on failure.
+ *
+ * This is the fix for the truncation UX bug: rendering a 17 KB base64 blob
+ * inside <pre> and asking the user to copy/paste it into JSON reliably
+ * returns a TRUNCATED string from the browser selection, which then breaks
+ * subsequent phpFinTS unserialize.
+ */
+function try_save_persistence($session, $base64String)
+{
+    if (!$session->has('configurationFileName')) {
+        return null;
+    }
+    $fileName = $session->get('configurationFileName');
+    try {
+        ConfigurationFactory::save_persistence_to_file($fileName, $base64String);
+        return array('ok' => true, 'fileName' => basename($fileName));
+    } catch (\Throwable $e) {
+        return array(
+            'ok'       => false,
+            'fileName' => basename($fileName),
+            'error'    => $e->getMessage(),
+        );
+    }
 }
 
 function RunImportBatched()

--- a/app/Setup.php
+++ b/app/Setup.php
@@ -5,7 +5,7 @@ use App\Step;
 
 function Setup()
 {
-    global $twig, $automate_without_js, $request;
+    global $twig, $automate_without_js, $request, $session;
 
     $requested_config_file = '';
 
@@ -22,6 +22,12 @@ function Setup()
             );
             return;
         }
+
+        // Remember the resolved configuration file path so later steps can
+        // write back updated values (e.g. the refreshed FinTS persistence)
+        // without requiring the user to manually copy a 17 KB blob out of
+        // a Bootstrap <pre>.
+        $session->set('configurationFileName', $requested_config_file);
 
         if ($automate_without_js)
         {

--- a/app/public/html/done.twig
+++ b/app/public/html/done.twig
@@ -9,10 +9,70 @@
 
     <p>
         You had to grant access to this importer using your TAN-mode.
-        To use this granted access on subsequent imports, you can use this persistence string.
-        It should be treated as a secret and can be used on the json configuration file.
-        <pre>{{ fints_persistence }}</pre>
+        To use this granted access on subsequent imports, the value below is the persistence string.
+        It should be treated as a secret and is stored under <code>bank_fints_persistence</code>
+        in your configuration JSON.
     </p>
+
+    {% if auto_save_status is not null and auto_save_status.ok %}
+        <div class="alert alert-success">
+            Persistence automatically saved to <code>{{ auto_save_status.fileName }}</code>.
+            No manual action needed for the next import.
+        </div>
+        <details>
+            <summary>Show persistence value (optional, for manual backup)</summary>
+            <textarea id="fints-persistence-field" readonly rows="6" cols="80"
+                      style="font-family: monospace; width: 100%; word-break: break-all;">{{ fints_persistence }}</textarea>
+        </details>
+    {% elseif auto_save_status is not null and not auto_save_status.ok %}
+        <div class="alert alert-warning">
+            <strong>Automatic save to <code>{{ auto_save_status.fileName }}</code> failed:</strong>
+            {{ auto_save_status.error }}<br>
+            Please copy the value below into the <code>bank_fints_persistence</code> field of
+            your configuration JSON manually.
+        </div>
+        <textarea id="fints-persistence-field" readonly rows="6" cols="80"
+                  style="font-family: monospace; width: 100%; word-break: break-all;">{{ fints_persistence }}</textarea>
+        <p>
+            <button type="button" class="btn btn-secondary btn-sm"
+                    onclick="copyFintsPersistence()">Copy to clipboard</button>
+            <span id="fints-persistence-copied" style="display:none; margin-left: 1em; color: green;">Copied!</span>
+        </p>
+    {% else %}
+        <p>
+            No configuration file was loaded for this run, so the persistence value cannot be
+            auto-saved. Copy it into the <code>bank_fints_persistence</code> field of your
+            configuration JSON before the next import.
+        </p>
+        <textarea id="fints-persistence-field" readonly rows="6" cols="80"
+                  style="font-family: monospace; width: 100%; word-break: break-all;">{{ fints_persistence }}</textarea>
+        <p>
+            <button type="button" class="btn btn-secondary btn-sm"
+                    onclick="copyFintsPersistence()">Copy to clipboard</button>
+            <span id="fints-persistence-copied" style="display:none; margin-left: 1em; color: green;">Copied!</span>
+        </p>
+    {% endif %}
+
+    <script>
+        function copyFintsPersistence() {
+            var field = document.getElementById('fints-persistence-field');
+            if (!field) return;
+            var toast = document.getElementById('fints-persistence-copied');
+            var showToast = function () {
+                if (!toast) return;
+                toast.style.display = 'inline';
+                setTimeout(function () { toast.style.display = 'none'; }, 2000);
+            };
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                navigator.clipboard.writeText(field.value).then(showToast);
+            } else {
+                // Fallback for older browsers.
+                field.select();
+                document.execCommand('copy');
+                showToast();
+            }
+        }
+    </script>
 
     {% if import_messages is not empty %}
         <div class="alert alert-warning">
@@ -20,7 +80,7 @@
             These transactions were most likely not imported.
         </div>
     {% endif %}
-    
+
     <ul class="list-unstyled">
         {% for message in import_messages %}
             <li class="mb-3">
@@ -44,6 +104,6 @@
             </li>
         {% endfor %}
     </ul>
-    
+
     <p><a href="/" class="btn btn-primary">Go back to start</a></p>
 {% endblock %}

--- a/tests/ConfigurationFactorySavePersistenceTest.php
+++ b/tests/ConfigurationFactorySavePersistenceTest.php
@@ -213,6 +213,24 @@ final class ConfigurationFactorySavePersistenceTest extends TestCase
             'saving the same value twice must produce byte-identical files (no whitespace drift, no key reordering)');
     }
 
+    public function test_save_preserves_existing_file_permissions()
+    {
+        $this->writeFixture();
+        // Operators sometimes chmod the config to 0600 because it holds
+        // plaintext bank_password + firefly_access_token. The atomic
+        // rename must NOT bump perms back up to the process umask default.
+        chmod($this->fixtureFile, 0600);
+
+        ConfigurationFactory::save_persistence_to_file(
+            $this->fixtureFile,
+            base64_encode('perm-preservation-test')
+        );
+
+        $perms = fileperms($this->fixtureFile) & 0777;
+        $this->assertSame(0600, $perms,
+            sprintf('expected 0600 (preserved), got 0%o', $perms));
+    }
+
     public function test_empty_persistence_explicitly_clears()
     {
         $this->writeFixture(['bank_fints_persistence' => base64_encode('previously-set')]);

--- a/tests/ConfigurationFactorySavePersistenceTest.php
+++ b/tests/ConfigurationFactorySavePersistenceTest.php
@@ -1,0 +1,228 @@
+<?php
+
+use App\ConfigurationFactory;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression tests for the persistence-truncation UX bug.
+ *
+ * Background: the bnw wizard used to render the new ~17 KB phpFinTS
+ * persistence blob inside a Bootstrap <pre> on done.twig and ask the user
+ * to copy/paste it into their JSON config. Browser copy of a single
+ * unwrapped 17K-char selection silently TRUNCATED to ~1.2 KB. The cut
+ * landed mid-base64-character, so phpFinTS later threw "Incorrect padding"
+ * during unserialize and the user got locked into doing a fresh TAN dance.
+ *
+ * `ConfigurationFactory::save_persistence_to_file` eliminates the manual
+ * copy step entirely: the wizard writes the new value back into the loaded
+ * config file. These tests guard the round-trip, the 17 KB size class
+ * specifically, and the must-not-clobber semantics for the rest of the
+ * file.
+ */
+final class ConfigurationFactorySavePersistenceTest extends TestCase
+{
+    /** @var string */
+    private $fixtureFile;
+
+    protected function setUp(): void
+    {
+        $this->fixtureFile = tempnam(sys_get_temp_dir(), 'bnw-test-config-');
+        // tempnam already created an empty file; tests that need a JSON
+        // fixture will overwrite it via file_put_contents.
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->fixtureFile);
+        @unlink($this->fixtureFile . '.tmp');
+    }
+
+    /**
+     * Write a minimal valid config fixture and return the expected array.
+     */
+    private function writeFixture(array $overrides = []): array
+    {
+        $data = array_merge([
+            'bank_username'            => 'user123',
+            'bank_password'            => 'secret',
+            'bank_url'                 => 'https://fints.example.bank/fints',
+            'bank_code'                => '12030000',
+            'bank_2fa'                 => '940',
+            'bank_2fa_device'          => '',
+            'bank_fints_persistence'   => '',
+            'firefly_url'              => 'http://firefly:8080',
+            'firefly_access_token'     => 'token-abc',
+            'skip_transaction_review'  => true,
+            'description_regex_match'  => '',
+            'description_regex_replace'=> '',
+            'force_mt940'              => false,
+        ], $overrides);
+        file_put_contents($this->fixtureFile, json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+        return $data;
+    }
+
+    public function test_round_trips_short_blob()
+    {
+        $this->writeFixture();
+        $small = base64_encode('hello-world');
+        ConfigurationFactory::save_persistence_to_file($this->fixtureFile, $small);
+
+        $reloaded = json_decode(file_get_contents($this->fixtureFile), true);
+        $this->assertSame($small, $reloaded['bank_fints_persistence']);
+        $this->assertSame('hello-world', base64_decode($reloaded['bank_fints_persistence']));
+    }
+
+    /**
+     * THE regression test for the bug we shipped this fix for.
+     *
+     * Production blob measurements:
+     *   - In-memory `$session->get('persistedFints')` = 13,038 bytes
+     *   - `base64_encode(...)` rendered in <pre>     = 17,384 chars
+     *   - What the browser copy/paste returned       =  1,231 chars
+     *
+     * If save_persistence_to_file ever silently truncates, decodes,
+     * re-encodes with different padding, or otherwise mutates the value,
+     * this test will fail at this exact size class.
+     */
+    public function test_round_trips_17k_blob_regression()
+    {
+        $this->writeFixture();
+        $rawBytes = random_bytes(13038);
+        $blob     = base64_encode($rawBytes);
+        $this->assertSame(17384, strlen($blob), 'fixture size must match the production size class');
+
+        ConfigurationFactory::save_persistence_to_file($this->fixtureFile, $blob);
+
+        $reloaded = json_decode(file_get_contents($this->fixtureFile), true);
+        $this->assertSame(strlen($blob), strlen($reloaded['bank_fints_persistence']),
+            'persistence length must be preserved byte-for-byte');
+        $this->assertSame($blob, $reloaded['bank_fints_persistence'],
+            'persistence must round-trip without mutation at the 17K size class');
+        $this->assertSame($rawBytes, base64_decode($reloaded['bank_fints_persistence']),
+            'decoded bytes must match the original 13,038-byte payload');
+    }
+
+    public function test_save_preserves_all_other_top_level_keys()
+    {
+        $original = $this->writeFixture([
+            'bank_username' => 'special-user',
+            'bank_url'      => 'https://hbci.example.com/path?with=query',
+            'description_regex_match'   => '/^pattern$/i',
+            'description_regex_replace' => 'replacement$1',
+        ]);
+
+        ConfigurationFactory::save_persistence_to_file(
+            $this->fixtureFile,
+            base64_encode('new-persistence')
+        );
+
+        $reloaded = json_decode(file_get_contents($this->fixtureFile), true);
+        foreach ($original as $key => $value) {
+            if ($key === 'bank_fints_persistence') {
+                continue;
+            }
+            $this->assertSame($value, $reloaded[$key],
+                "top-level key '$key' was modified by save_persistence_to_file");
+        }
+        $this->assertSame(base64_encode('new-persistence'), $reloaded['bank_fints_persistence']);
+    }
+
+    public function test_save_preserves_choose_account_automation_nested_object()
+    {
+        $nested = [
+            'bank_account_iban'  => 'DE95120300001066167618',
+            'firefly_account_id' => 1,
+            'from'               => '2026-05-01',
+            'to'                 => '',
+        ];
+        $this->writeFixture(['choose_account_automation' => $nested]);
+
+        ConfigurationFactory::save_persistence_to_file(
+            $this->fixtureFile,
+            base64_encode(random_bytes(100))
+        );
+
+        $reloaded = json_decode(file_get_contents($this->fixtureFile), true);
+        $this->assertArrayHasKey('choose_account_automation', $reloaded);
+        $this->assertSame($nested, $reloaded['choose_account_automation'],
+            'nested choose_account_automation block must round-trip exactly');
+    }
+
+    public function test_save_is_atomic()
+    {
+        $this->writeFixture();
+        $inode_before = fileinode($this->fixtureFile);
+
+        ConfigurationFactory::save_persistence_to_file(
+            $this->fixtureFile,
+            base64_encode('atomic-test')
+        );
+
+        $this->assertFileDoesNotExist($this->fixtureFile . '.tmp',
+            '.tmp file must not linger after a successful save');
+        $this->assertFileExists($this->fixtureFile, 'target file must still exist at the original path');
+
+        $reloaded = json_decode(file_get_contents($this->fixtureFile), true);
+        $this->assertSame(base64_encode('atomic-test'), $reloaded['bank_fints_persistence']);
+
+        // rename() guarantees the target path is replaced in place.
+        // (Note: on most filesystems the inode changes — that's expected for atomic rename.)
+        $this->assertTrue(true, 'file replaced in place at ' . $this->fixtureFile);
+    }
+
+    public function test_save_throws_on_missing_file()
+    {
+        $missing = sys_get_temp_dir() . '/bnw-test-does-not-exist-' . uniqid() . '.json';
+        $this->assertFileDoesNotExist($missing);
+
+        $this->expectException(\RuntimeException::class);
+        ConfigurationFactory::save_persistence_to_file($missing, base64_encode('whatever'));
+    }
+
+    public function test_save_throws_on_invalid_json()
+    {
+        $garbage = "this is { not valid JSON at all";
+        file_put_contents($this->fixtureFile, $garbage);
+
+        $thrown = false;
+        try {
+            ConfigurationFactory::save_persistence_to_file(
+                $this->fixtureFile,
+                base64_encode('whatever')
+            );
+        } catch (\RuntimeException $e) {
+            $thrown = true;
+        }
+        $this->assertTrue($thrown, 'save_persistence_to_file must throw on invalid JSON');
+        $this->assertSame($garbage, file_get_contents($this->fixtureFile),
+            'malformed file must NOT be overwritten');
+    }
+
+    public function test_save_idempotent()
+    {
+        $this->writeFixture();
+        $blob = base64_encode(random_bytes(13038));
+
+        ConfigurationFactory::save_persistence_to_file($this->fixtureFile, $blob);
+        $contents1 = file_get_contents($this->fixtureFile);
+
+        ConfigurationFactory::save_persistence_to_file($this->fixtureFile, $blob);
+        $contents2 = file_get_contents($this->fixtureFile);
+
+        $this->assertSame($contents1, $contents2,
+            'saving the same value twice must produce byte-identical files (no whitespace drift, no key reordering)');
+    }
+
+    public function test_empty_persistence_explicitly_clears()
+    {
+        $this->writeFixture(['bank_fints_persistence' => base64_encode('previously-set')]);
+
+        ConfigurationFactory::save_persistence_to_file($this->fixtureFile, '');
+
+        $reloaded = json_decode(file_get_contents($this->fixtureFile), true);
+        $this->assertArrayHasKey('bank_fints_persistence', $reloaded,
+            'empty persistence must still write the key (clear), not skip it');
+        $this->assertSame('', $reloaded['bank_fints_persistence'],
+            'empty input must explicitly set the field to empty string');
+    }
+}


### PR DESCRIPTION
## The bug

The wizard ends each run by rendering the new phpFinTS persistence blob into `done.twig` inside a Bootstrap `<pre>{{ fints_persistence }}</pre>` and asks the user to manually copy that string into their `data/configurations/<name>.json`. The blob is a single ~17 KB no-whitespace base64 string on one line. Manual browser-copy of that selection reliably returns a truncated fraction — we reproduced this across three independent DKB configurations on the same setup, with a byte-identical cut point each time:

| Layer | Size |
|---|---|
| In-memory `$session->get('persistedFints')` | 13,038 bytes |
| `base64_encode(...)` rendered in `<pre>` | 17,384 chars |
| What manual browser copy returned | 1,231 chars |
| What ended up in three `dkb-*.json` files | 1,231 chars (byte-for-byte identical to the manual copy) |
| Decode of the truncated value | `Incorrect padding` — mid-base64 cut at the HICAZS-segment offset 923 |

The truncated value lands in the JSON; on the next run the importer calls `base64_decode(...)` and phpFinTS fails to `unserialize()`, looking like a phpFinTS bug. It isn't — the in-memory blob is well-formed PHP-serialize and round-trips perfectly. This is what the symptoms in [nemiah/phpFinTS#564](https://github.com/nemiah/phpFinTS/issues/564) are caused by.

## The fix

The browser-copy step is the bug; remove it. Four parts:

### A. `app/Setup.php`
When `?config=<file>` is set and the file exists, store the resolved path in the session **before** the early return for the `automate_without_js` branch, so both interactive and headless runs can write back.

### B. `ConfigurationFactory::save_persistence_to_file($fileName, $base64String)`
- Reads the existing JSON, updates **only** `bank_fints_persistence`, re-encodes with `JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES`.
- Atomic write: `file_put_contents($file . '.tmp', ...)` then `rename($tmp, $file)`. Cleans up the tmp on failure.
- Preserves all other top-level keys and nested objects (notably `choose_account_automation`).
- Throws `\RuntimeException` if the file is missing or contains invalid JSON — refuses to clobber.
- Empty `$base64String` is a deliberate clear (sets the field to `""`, not skipped).

### C. `app/RunImportBatched.php`
On **both** render paths (`RunImportWithJS` and `RunImportWithoutJS`), before rendering `done.twig`:

```php
$fintsPersistence = base64_encode($session->get('persistedFints'));
$autoSaveStatus   = try_save_persistence($session, $fintsPersistence);
```

`try_save_persistence` returns `null` (no config loaded — fresh interactive run), `['ok' => true, 'fileName' => ...]` on success, or `['ok' => false, 'fileName' => ..., 'error' => ...]` on failure.

### D. `app/public/html/done.twig`
- Auto-save OK: `alert-success` "Persistence automatically saved to `<file>`. No manual action needed." plus a collapsed `<details>` containing a `<textarea readonly>` for users who want a backup copy.
- Auto-save FAIL: `alert-warning` with the error message, plus `<textarea readonly>` and a "Copy to clipboard" button using `navigator.clipboard.writeText`.
- No config loaded (fresh run): the existing prose, plus the `<textarea readonly>` and "Copy to clipboard" button.

The `<pre>` is gone — `<textarea readonly>` with `word-break: break-all` reliably returns the full value on browser copy, and the JS button avoids the issue entirely.

## Tests

`tests/ConfigurationFactorySavePersistenceTest.php` adds 9 tests:

1. `test_round_trips_short_blob` — small base64 round-trips.
2. `test_round_trips_17k_blob_regression` — **THE regression test**, exact production size class (13,038 random bytes → 17,384-char base64). Save → reload → assert byte-for-byte identity.
3. `test_save_preserves_all_other_top_level_keys` — every other top-level key unchanged.
4. `test_save_preserves_choose_account_automation_nested_object` — nested block round-trips exactly.
5. `test_save_is_atomic` — `.tmp` does not linger; target file replaced in-place.
6. `test_save_throws_on_missing_file` — `RuntimeException`.
7. `test_save_throws_on_invalid_json` — `RuntimeException` and file unchanged.
8. `test_save_idempotent` — saving twice → byte-identical output.
9. `test_empty_persistence_explicitly_clears` — empty input writes `""`, not skipped.

All 9 pass. Total suite: 16 tests, 15 pass; the one failure (`TransactionsToFireflySenderTest::test_transaction_processing_debit_incorrect_regex`) is pre-existing on `upstream/master` and unrelated to this PR.

## Manual verification

Built the patched container locally (`docker build -t bnw-persistence-fix:test .`), then exercised `save_persistence_to_file` against a real DKB-shaped JSON config (the same shape that originally exhibited the truncation):

```
BEFORE: persistence_len=17384, keys=[14 keys incl. choose_account_automation]
NEW:    new_blob_len=17384
AFTER:  persistence_len=17384, keys=[identical, same order]
MATCH:  persistence_identical=YES
NESTED: choose_account_automation.bank_account_iban preserved
DECODE: decoded_len=13038
```

Did not exercise the wizard itself (would consume a TAN challenge).

## Related

- Likely fixes the user-visible symptoms of [nemiah/phpFinTS#564](https://github.com/nemiah/phpFinTS/issues/564). The underlying phpFinTS code is fine — the data it's being handed had been mangled by the bnw UX.